### PR TITLE
Fixed compilation on MacOsX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,21 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 # find the LCIO directory
 if (LCIO_DIR)
     set(LCIO_INCLUDE_DIR "${LCIO_DIR}/include")
+
+    #TEMPORARY: if MacOs LCIO standard compilation creates dynamic libs. Correct for that. 
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(LCIO_LIBRARY "${LCIO_DIR}/lib/liblcio.dylib")
+    else()
     set(LCIO_LIBRARY "${LCIO_DIR}/lib/liblcio.so")
+    endif()	       
+
+
     if (NOT EXISTS "${LCIO_DIR}")
         message(FATAL_ERROR "Unable to find LCIO library")
     endif()
     message(STATUS "LCIO dir set to: ${LCIO_DIR}")
+
+    #The following are not necessary - should clean up
     message(STATUS "LCIO include dir set to: ${LCIO_INCLUDE_DIR}")
     message(STATUS "LCIO library set to: ${LCIO_LIBRARY}")
 endif()

--- a/cmake/Modules/MacroModule.cmake
+++ b/cmake/Modules/MacroModule.cmake
@@ -99,7 +99,7 @@ macro(MODULE)
     add_library(${MODULE_NAME} SHARED ${sources} ${MODULE_EXTRA_SOURCES})
    
     # add link libs
-    target_link_libraries(${MODULE_NAME} ${MODULE_EXTRA_LINK_LIBRARIES})
+    target_link_libraries(${MODULE_NAME} ${MODULE_LIBRARIES} ${MODULE_EXTRA_LINK_LIBRARIES})
   
     # install the library
     install(TARGETS ${MODULE_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)

--- a/processing/include/ParameterSet.h
+++ b/processing/include/ParameterSet.h
@@ -13,6 +13,7 @@
 #include <map>
 #include <stdexcept>
 #include <vector>
+#include <string>
 
 class ParameterSet { 
 


### PR DESCRIPTION
- check on os; if Mac use .dylib extension instead of .so for LCIO 
- add ${MODULE_LIBRARIES} to module linking stage
- include missing fixed

test:
- tested compilation on MacOsX and centos7