### PR TITLE
Adding Simulated Tracker Hits

### DIFF
--- a/event/include/Collections.h
+++ b/event/include/Collections.h
@@ -46,7 +46,7 @@ namespace Collections {
     /** Name of the collection containing MC Particles. */
     constexpr const char* MC_PARTICLES{"MCParticle"}; 
 
-    /** Name of the collection containing MC Particles. */
+    /** Name of the collection containing MC Tracker Hits. */
     constexpr const char* MC_TRACKER_HITS{"TrackerHits"}; 
 
     /** Name of time corrected ECal hits collection. */

--- a/event/include/Collections.h
+++ b/event/include/Collections.h
@@ -46,6 +46,9 @@ namespace Collections {
     /** Name of the collection containing MC Particles. */
     constexpr const char* MC_PARTICLES{"MCParticle"}; 
 
+    /** Name of the collection containing MC Particles. */
+    constexpr const char* MC_TRACKER_HITS{"TrackerHits"}; 
+
     /** Name of time corrected ECal hits collection. */
     constexpr const char* ECAL_TIME_CORR_HITS{"TimeCorrEcalHits"}; 
 

--- a/event/include/EventDef.h
+++ b/event/include/EventDef.h
@@ -11,4 +11,5 @@
 #include "Track.h"
 #include "Vertex.h"
 #include "TrackerHit.h"
+#include "MCTrackerHit.h"
 #include "RawSvtHit.h"

--- a/event/include/EventLinkDef.h
+++ b/event/include/EventLinkDef.h
@@ -28,6 +28,7 @@
 #pragma link C++ class Track+;
 #pragma link C++ class Vertex+;
 #pragma link C++ class TrackerHit+;
+#pragma link C++ class MCTrackerHit+;
 #pragma link C++ class RawSvtHit+;
 
 // This is to create the dictionary for stl containers
@@ -37,6 +38,8 @@
 #pragma link C++ class vector<RawSvtHit*>  +;
 #pragma link C++ class vector<TrackerHit>  +;
 #pragma link C++ class vector<TrackerHit*> +;
+#pragma link C++ class vector<MCTrackerHit>  +;
+#pragma link C++ class vector<MCTrackerHit*> +;
 #pragma link C++ class vector<Track>       +;
 #pragma link C++ class vector<Track*>      +;
 #pragma link C++ class vector<Vertex*>     +;

--- a/event/include/MCTrackerHit.h
+++ b/event/include/MCTrackerHit.h
@@ -1,0 +1,112 @@
+/**
+ * @file MCTrackerHit.h
+ * @brief Class used to encapsulate mc tracker hit information
+ * @author Cameron Bravo, SLAC National Accelerator Laboratory
+ */
+
+#ifndef _MCTRACKER_HIT_H_
+#define _MCTRACKER_HIT_H_
+
+//----------------//
+//   C++ StdLib   //
+//----------------//
+#include <iostream>
+
+//----------//
+//   ROOT   //
+//----------//
+#include <TObject.h>
+#include <TClonesArray.h>
+#include <TRefArray.h>
+
+class MCTrackerHit : public TObject { 
+
+    public: 
+
+        /** Constructor */
+        MCTrackerHit();
+
+        /** Destructor */
+        virtual ~MCTrackerHit();
+
+        /** Reset the Hit object. */
+        void Clear(Option_t *option="");
+
+        /**
+         * Set the hit position.
+         *
+         * @param position The hit position.
+         */
+        void setPosition(const double* position, bool rotate = false);
+
+        /** @return The hit position. */
+        std::vector<double> getPosition() const { return {x_, y_, z_}; };
+
+        /** @return the global X coordinate of the hit */
+        double getGlobalX() const {return x_;}
+
+        /** @return the global X coordinate of the hit */
+        double getGlobalY() const {return y_;}
+
+        /** @return the global X coordinate of the hit */
+        double getGlobalZ() const {return z_;}
+
+        /**
+         * Set the hit time.
+         *
+         * @param time The hit time.
+         */
+        void setTime(const double time) { time_ = time; };
+
+        /** @return The hit time. */
+        double getTime() const { return time_; };
+
+        /**
+         * Set the hit energy deposit.
+         *
+         * @param charge The hit energy.
+         */
+        void setEdep(const double edep) { edep_ = edep; };
+
+        /** @return The hit energy deposit. */
+        double getEdep() const { return edep_; };
+
+        void setModule(const int module ) {module_ = module;} ;
+
+        //** @return the tracker hit volume from the raw hit content */
+        int getModule() { return module_;} ;
+
+        //** set the tracker hit layer from the raw hit content */
+        void setLayer(const int layer) {layer_ = layer;};
+
+        //** @return the tracker hit layer from the raw hit content */
+        int getLayer() const {return layer_;};
+
+        ClassDef(MCTrackerHit, 1);	
+
+    private:
+
+        /** The x position of the hit. */
+        double x_{-999}; 
+
+        /** The x position of the hit. */
+        double y_{-999}; 
+
+        /** The x position of the hit. */
+        double z_{-999};
+
+        /** The hit time. */
+        double time_{-999};
+
+        /** Layer (Axial + Stereo). 1-12 in 2015/2016 geometry, 1-14 in 2019 geometry */
+        int layer_{-999};
+
+        /** Module */
+        int module_{-999};
+
+        /** Raw charge: sum of the raw hit fit amplitudes */
+        float edep_{-999};
+
+}; // MCTrackerHit
+
+#endif // _MCTRACKER_HIT_H_

--- a/event/include/MCTrackerHit.h
+++ b/event/include/MCTrackerHit.h
@@ -104,7 +104,7 @@ class MCTrackerHit : public TObject {
         /** Module */
         int module_{-999};
 
-        /** Raw charge: sum of the raw hit fit amplitudes */
+        /** Energy deposit of hit */
         float edep_{-999};
 
 }; // MCTrackerHit

--- a/event/src/MCTrackerHit.cxx
+++ b/event/src/MCTrackerHit.cxx
@@ -1,0 +1,40 @@
+/**
+ * @file MCTrackerHit.cxx
+ * @brief Class used to encapsulate mc tracker hit information
+ * @author Cameron Bravo, SLAC National Accelerator Laboratory
+ */
+
+#include "MCTrackerHit.h"
+
+ClassImp(MCTrackerHit)
+
+MCTrackerHit::MCTrackerHit()
+    : TObject() { 
+    }
+
+MCTrackerHit::~MCTrackerHit() { 
+    Clear(); 
+}
+
+void MCTrackerHit::Clear(Option_t* /* options */) { 
+    TObject::Clear(); 
+}
+
+void MCTrackerHit::setPosition(const double* position, bool rotate) {
+
+    //svt angle: it's already with minus sign.
+    float svtAngle = 30.5e-3;
+    //Rotate the the input position automatically to match with the SVT tracker system
+    if (rotate)
+    {
+        //x_ = position[1];
+        y_ = position[2];
+        z_ = position[1] * sin(svtAngle) + position[0]*cos(svtAngle);
+        x_ = position[1] * cos(svtAngle) - position[0]*sin(svtAngle);
+    }
+    else {
+        x_ = position[0]; 
+        y_ = position[1];
+        z_ = position[2];
+    }
+}

--- a/processors/include/MCTrackerHitProcessor.h
+++ b/processors/include/MCTrackerHitProcessor.h
@@ -1,0 +1,77 @@
+/**
+ *
+ */
+
+#ifndef __MCTRACKERHIT_PROCESSOR_H__
+#define __MCTRACKERHIT_PROCESSOR_H__
+
+//-----------------//
+//   C++  StdLib   //
+//-----------------//
+#include <iostream>
+#include <algorithm>
+#include <string>
+
+//----------//
+//   LCIO   //
+//----------//
+#include <EVENT/LCCollection.h>
+#include <EVENT/SimTrackerHit.h>
+#include <UTIL/BitField64.h>
+
+//----------//
+//   ROOT   //
+//----------//
+#include "TClonesArray.h"
+#include "TTree.h"
+
+//-----------//
+//   hpstr   //
+//-----------//
+#include "Collections.h"
+#include "Processor.h"
+#include "MCTrackerHit.h"
+#include "Event.h"
+
+class MCTrackerHitProcessor : public Processor { 
+
+    public: 
+
+        /**
+         * Class constructor. 
+         *
+         * @param name Name for this instance of the class.
+         * @param process The Process class associated with Processor, provided
+         *                by the processing framework.
+         */
+        MCTrackerHitProcessor(const std::string& name, Process& process); 
+
+        /** Destructor */
+        ~MCTrackerHitProcessor(); 
+
+        /**
+         * Process the event and put new data products into it.
+         * @param event The Event to process.
+         */
+        virtual bool process(IEvent* ievent);
+
+        /**
+         * Callback for the Processor to take any necessary
+         * action when the processing of events starts.
+         */
+        virtual void initialize(TTree* tree);
+
+        /**
+         * Callback for the Processor to take any necessary
+         * action when the processing of events finishes.
+         */
+        virtual void finalize();
+
+    private: 
+
+        /** Container to hold all TrackerHit objects. */
+        TClonesArray* trackerhits_{nullptr}; 
+
+}; // MCTrackerHitProcessor
+
+#endif // __MCTRACKERHIT_PROCESSOR_H__

--- a/processors/src/MCTrackerHitProcessor.cxx
+++ b/processors/src/MCTrackerHitProcessor.cxx
@@ -1,0 +1,68 @@
+/**
+ * @file MCTrackerHitProcessor.h
+ * @brief Processor used to add simulated tracker hits to the event
+ * @author Cameron Bravo, SLAC National Accelerator Laboratory
+ */
+#include "MCTrackerHitProcessor.h" 
+
+MCTrackerHitProcessor::MCTrackerHitProcessor(const std::string& name, Process& process)
+    : Processor(name, process) { 
+}
+
+MCTrackerHitProcessor::~MCTrackerHitProcessor() { 
+}
+
+void MCTrackerHitProcessor::initialize(TTree* tree) {
+
+    trackerhits_   = new TClonesArray("MCTrackerHit", 100000);  
+    tree->Branch(Collections::MC_TRACKER_HITS,&trackerhits_);
+}
+
+bool MCTrackerHitProcessor::process(IEvent* ievent) {
+  
+    Event* event = static_cast<Event*>(ievent);
+    // Get the collection of simulated tracker hits from the LCIO event.
+    EVENT::LCCollection* lcio_trackerhits = event->getLCCollection(Collections::MC_TRACKER_HITS);
+
+    // Get decoders to read cellids
+    UTIL::BitField64 decoder("system:0:6,barrel:6:3,layer:9:4,module:13:12,sensor:25:1,side:32:-2,strip:34:12");
+    //decoder[field] returns the value
+
+    // Loop over all of the raw SVT hits in the LCIO event and add them to the 
+    // HPS event
+    trackerhits_->Clear();
+    for (int ihit = 0; ihit < lcio_trackerhits->getNumberOfElements(); ++ihit) {
+
+      // Get a 3D hit from the list of hits
+        EVENT::SimTrackerHit* lcio_mcTracker_hit 
+            = static_cast<EVENT::SimTrackerHit*>(lcio_trackerhits->getElementAt(ihit));
+        //Decode the cellid
+        EVENT::long64 value = EVENT::long64( lcio_mcTracker_hit->getCellID0() & 0xffffffff ) | 
+            ( EVENT::long64( lcio_mcTracker_hit->getCellID1() ) << 32 ) ;
+        decoder.setValue(value);
+
+        // Add a raw tracker hit to the event
+        MCTrackerHit* mc_tracker_hit = static_cast<MCTrackerHit*>(trackerhits_->ConstructedAt(ihit));
+
+        // Set sensitive detector identification
+        mc_tracker_hit->setLayer(decoder["layer"]);
+        mc_tracker_hit->setModule(decoder["module"]);
+
+        // Set the position of the hit
+        mc_tracker_hit->setPosition(lcio_mcTracker_hit->getPosition());
+
+        // Set the energy deposit of the hit
+        mc_tracker_hit->setEdep(lcio_mcTracker_hit->getEDep());
+
+        // Set the time of the hit
+        mc_tracker_hit->setTime(lcio_mcTracker_hit->getTime());
+
+    }
+
+    return true;
+}
+
+void MCTrackerHitProcessor::finalize() { 
+}
+
+DECLARE_PROCESSOR(MCTrackerHitProcessor); 


### PR DESCRIPTION
Simulated tracker hits are added as MCTrackerHit in event. A corresponding processor is also added.