### PR TITLE
Iss6 hotfix

### DIFF
--- a/processing/src/ConfigurePython.cxx
+++ b/processing/src/ConfigurePython.cxx
@@ -58,14 +58,20 @@ ConfigurePython::ConfigurePython(const std::string& python_script, char* args[],
     if (nargs > 0) {
 #if PY_MAJOR_VERSION >= 3
       wchar_t** targs = new wchar_t*[nargs + 1];
-#if PY_MINOR_VERION >=5
+
+#if PY_MINOR_VERSION >=5 // Python 3.4 is missing the Py_DecodeLocale() method.
       targs[0] = Py_DecodeLocale(python_script.c_str(),NULL);
       for (int i = 0; i < nargs; i++)
           targs[i + 1] = Py_DecodeLocale(args[i],NULL);
-#else
-      targs[0] = PyUnicode_AsUnicode(PyUnicode_DecodeLocale(python_script.c_str(),NULL));
-      for (int i = 0; i < nargs; i++)
-	  targs[i + 1] = PyUnicode_AsUnicode(PyUnicode_DecodeLocale(args[i],NULL));
+#else // Code for Python 3.4, where Py_DecodeLocale is missing.
+      PyObject *tmpstr = PyUnicode_DecodeLocale(python_script.c_str(),NULL);
+      targs[0] = PyUnicode_AsUnicode(tmpstr);
+      Py_DECREF(tmpstr);
+        for (int i = 0; i < nargs; i++){
+          tmpstr = PyUnicode_DecodeLocale(args[i],NULL);
+          targs[i + 1] = PyUnicode_AsUnicode(tmpstr);
+          Py_DECREF(tmpstr);
+        }
 
 #endif      
       PySys_SetArgv(nargs+1, targs);

--- a/processing/src/ConfigurePython.cxx
+++ b/processing/src/ConfigurePython.cxx
@@ -64,17 +64,18 @@ ConfigurePython::ConfigurePython(const std::string& python_script, char* args[],
       for (int i = 0; i < nargs; i++)
           targs[i + 1] = Py_DecodeLocale(args[i],NULL);
 #else // Code for Python 3.4, where Py_DecodeLocale is missing.
-      PyObject *tmpstr = PyUnicode_DecodeLocale(python_script.c_str(),NULL);
-      targs[0] = PyUnicode_AsUnicode(tmpstr);
+      PyObject *tmpstr = PyUnicode_FromString(python_script.c_str());
+      targs[0] = PyUnicode_AsWideCharString(tmpstr,NULL);
       Py_DECREF(tmpstr);
         for (int i = 0; i < nargs; i++){
-          tmpstr = PyUnicode_DecodeLocale(args[i],NULL);
-          targs[i + 1] = PyUnicode_AsUnicode(tmpstr);
+          tmpstr = PyUnicode_FromString(args[i]);
+          targs[i + 1] = PyUnicode_AsWideCharString(tmpstr,NULL);
           Py_DECREF(tmpstr);
         }
 
 #endif      
-      PySys_SetArgv(nargs+1, targs);
+      PySys_SetArgvEx(nargs+1, targs,1);
+      for(int i=0;i<nargs+1; i++) PyMem_RawFree(targs[i]);
       delete[] targs;
 #else
       char** targs = new char*[nargs + 1];

--- a/processing/src/ConfigurePython.cxx
+++ b/processing/src/ConfigurePython.cxx
@@ -58,10 +58,16 @@ ConfigurePython::ConfigurePython(const std::string& python_script, char* args[],
     if (nargs > 0) {
 #if PY_MAJOR_VERSION >= 3
       wchar_t** targs = new wchar_t*[nargs + 1];
+#if PY_MINOR_VERION >=5
       targs[0] = Py_DecodeLocale(python_script.c_str(),NULL);
       for (int i = 0; i < nargs; i++)
           targs[i + 1] = Py_DecodeLocale(args[i],NULL);
-      
+#else
+      targs[0] = PyUnicode_AsUnicode(PyUnicode_DecodeLocale(python_script.c_str(),NULL));
+      for (int i = 0; i < nargs; i++)
+	  targs[i + 1] = PyUnicode_AsUnicode(PyUnicode_DecodeLocale(args[i],NULL));
+
+#endif      
       PySys_SetArgv(nargs+1, targs);
       delete[] targs;
 #else


### PR DESCRIPTION
Some additional changes were needed to accommodate Python 3.4, which does not have the same Unicode decoder as 3.5+. At JLab the ROOT 6 versions are linked against Python 3.4, so adding this is desirable.