### PR TITLE
Add process run mode and port in bump-hunter

### DIFF
--- a/analysis/include/BumpHunter.h
+++ b/analysis/include/BumpHunter.h
@@ -1,0 +1,277 @@
+/**
+ * @file BumpHunter.h
+ * @brief
+ * @author Omar Moreno <omoreno1@ucsc.edu>
+ *         Santa Cruz Institute for Particle Physics
+ *         University of California, Santa Cruz
+ * @date January 14, 2015
+ */
+
+#ifndef __BUMP_HUNTER_H__
+#define __BUMP_HUNTER_H__
+
+//----------------//   
+//   C++ StdLib   //
+//----------------//  
+#include <cmath>
+#include <cstdio> 
+#include <exception>
+#include <fstream>
+#include <map>
+#include <vector>
+
+//----------//
+//   ROOT   //
+//----------// 
+#include <TF1.h> 
+#include <TFitResult.h>
+#include <TFitResultPtr.h>
+#include <TH1.h>
+#include <TMath.h>
+#include <TCanvas.h>
+#include <TFile.h>
+#include <TRandom.h>
+
+#include <Math/ProbFunc.h>
+
+//---//
+#include <HpsFitResult.h>
+
+class BumpHunter {
+
+    public:
+
+        /** Enum constants used to denote the different background models. */
+        enum BkgModel { 
+            POLY     = 0,
+            EXP_POLY = 1,
+            EXP_POLY_X_POLY = 2,
+        };
+
+        /** Default Constructor */
+        BumpHunter(BkgModel model, int poly_order, int res_factor);
+
+        /** Destructor */
+        ~BumpHunter();
+        
+        /** 
+         * Perform a search for a resonance at the given mass hypothesis.
+         *
+         * @param histogram Histogram containing the mass spectrum that will be
+         *                  used to search for a resonance.
+         * @param mass_hypothesis The mass of interest.
+         */
+        HpsFitResult* performSearch(TH1* histogram, double mass_hypothesis, bool skip_bkg_fit, bool skip_ul); 
+
+        /** 
+         * Given the mass of interest, setup the window parameters and 
+         * initialize the fit parameters.  This includes setting the size of the
+         * window and the window edges as well as estimating the initial value
+         * of some fit parameters.
+         *
+         * @param histogram Histogram containing the mass spectrum that will be
+         *                  used to search for a resonance.
+         * @param mass_hypothesis The mass of interest.
+         */
+        void initialize(TH1* histogram, double &mass_hypothesis); 
+
+        /**
+         *
+         */
+        void calculatePValue(HpsFitResult* result); 
+
+
+        /** Fit using a background only model. */
+        void fitBkgOnly();
+
+        /** Set the histogram bounds. */
+        void setBounds(double low_bound, double high_bound); 
+
+        /** Enable/disable debug */
+        void enableDebug(bool debug = true) { this->debug = debug; };
+
+        /** Enable batch running. */
+        void runBatchMode(bool batch = true) { _batch = batch; };
+
+        /** Write the fit results to a text file */
+        void writeResults(bool write_results = true) { _write_results = write_results; }; 
+
+        /** Get the signal upper limit. */
+        void getUpperLimit(TH1* histogram, HpsFitResult* result); 
+
+        /** */
+        std::vector<TH1*> generateToys(TH1* histogram, double n_toys, int seed);
+
+    private:
+
+        /**
+         * Get the HPS mass resolution at the given mass.  The functional form 
+         * of the mass resolution was determined using MC.
+         *
+         * @param mass The mass of interest.
+         * @return The mass resolution at the given mass.
+         */
+        inline double getMassResolution(double mass) { 
+            //return -6.2*mass*mass*mass + 0.91*mass*mass - 0.00297*mass + 0.000579; 
+            //return 0.0389938364847*mass - 0.0000713783511061; // ideal
+            //return 0.0501460737193*mass - 0.0000917925595224; // scaled to moller mass from data
+            //return 0.0532190838657*mass - 0.0000922283032152; // scaled to moller mass + sys
+            return 1.56*(0.000955 - 0.004198 * mass + 0.2367 * mass * mass - 0.7009 * mass * mass * mass);
+        };
+
+        /**
+         *
+         */
+        double correctMass(double mass); 
+  
+        /** 
+         * Print debug statement.
+         *
+         * @param message Debug statement to print.
+         */
+        void printDebug(std::string message); 
+         
+        /**
+         *
+         */
+        void getChi2Prob(double min_nll_null, double min_nll, double &q0, double &p_value); 
+
+
+        /** Background only fit result. */
+        HpsFitResult* bkg_only_result_{nullptr};
+
+        /** Output file stream */
+        std::ofstream* ofs;
+
+        //
+        // Variable definitions
+        //
+
+        /** The mass after the mass scale correction. */
+        double corr_mass_{0};
+
+        /** The lower bound of the histogram. */
+        double lower_bound{0.016};
+
+        /** The upper bound of the histogram. */
+        double upper_bound_{0.115};
+
+        /** The total number of events within the fit window. */
+        double integral_{0}; 
+
+        /** 
+         * Resolution multiplicative factor used in determining the fit window 
+         * size.
+         */
+        double res_factor_{13}; 
+
+        /** Size of the background window that will be used to fit. */
+        double window_size_{0};
+
+        /** The total number of bins */
+        int bins_{0};
+
+        /** Polynomial order used to model the background. */
+        int poly_order_{0};
+
+        /** 
+         * Flag denoting if application should run in batch mode.  If set to 
+         * true, plots aren't generated and fit results aren't logged.
+         */
+        bool _batch{false}; 
+
+        /** Debug flag */
+        bool debug{false};
+
+        /** Write the results to a file. */
+        bool _write_results{false};
+
+        double window_start_{0}; 
+
+        double window_end_{0};
+
+        double mass_hypothesis_{0}; 
+
+        double mass_resolution_{0};  
+};
+
+//
+// TODO: Move the classes externally 
+//
+
+class ExpPol3BkgFunction { 
+    
+    public: 
+
+        /** Constructor */
+        ExpPol3BkgFunction(double mass_hypothesis, double window_size); 
+
+        double operator() (double* x, double* par); 
+
+    private: 
+
+        /** Mass hypothesis */
+        double mass_hypothesis_{0}; 
+
+        /** Size of the search window. */
+        double window_size_{0};
+
+         
+};
+
+
+class ExpPol5BkgFunction { 
+    
+    public: 
+
+        /** Constructor */
+        ExpPol5BkgFunction(double mass_hypothesis, double window_size); 
+
+        double operator() (double* x, double* par); 
+
+    private: 
+
+        /** Mass hypothesis */
+        double mass_hypothesis_{0}; 
+
+        /** Size of the search window. */
+        double window_size_{0};
+
+         
+};
+
+
+class ExpPol5FullFunction { 
+    
+    public: 
+
+        /** Constructor */
+        ExpPol5FullFunction(double mass_hypothesis, double window_size); 
+
+        double operator() (double* x, double* par); 
+
+    private: 
+
+        double mass_hypothesis_{0}; 
+
+        double window_size_{0}; 
+};
+
+
+class ExpPol3FullFunction { 
+    
+    public: 
+
+        /** Constructor */
+        ExpPol3FullFunction(double mass_hypothesis, double window_size); 
+
+        double operator() (double* x, double* par); 
+
+    private: 
+
+        double mass_hypothesis_{0}; 
+
+        double window_size_{0}; 
+};
+
+#endif // __BUMP_HUNTER_H__

--- a/analysis/include/BumpHunter.h
+++ b/analysis/include/BumpHunter.h
@@ -151,7 +151,7 @@ class BumpHunter {
         double corr_mass_{0};
 
         /** The lower bound of the histogram. */
-        double lower_bound{0.016};
+        double lower_bound_{0.016};
 
         /** The upper bound of the histogram. */
         double upper_bound_{0.115};

--- a/analysis/include/FlatTupleMaker.h
+++ b/analysis/include/FlatTupleMaker.h
@@ -1,0 +1,83 @@
+/*
+ * @file FlatTupleMaker.h
+ * @author Omar Moreno
+ * @date January 18, 2016
+ * @brief 
+ *
+ */
+
+#ifndef __FLAT_TUPLE_MAKER_H__
+#define __FLAT_TUPLE_MAKER_H__
+
+//----------------//   
+//   C++ StdLib   //
+//----------------//   
+#include <string>
+#include <map>
+#include <iostream>
+
+//----------//
+//   ROOT   //
+//----------//
+#include <TFile.h>
+#include <TTree.h>
+
+class FlatTupleMaker {
+
+    public:
+
+        /** 
+         * Constructor
+         *  
+         */
+        FlatTupleMaker(std::string file_name, std::string tree_name);
+
+        /** Destructor */
+        ~FlatTupleMaker();
+
+        /**
+         *
+         */
+        void addVariable(std::string variable_name);
+
+        void addVector(std::string vector_name); 
+
+        /**
+         *
+         */
+        void setVariableValue(std::string variable_name, double value) { variables[variable_name] = value; }; 
+
+        void addToVector(std::string variable_name, double value); 
+
+        /**
+         *
+         */
+        bool hasVariable(std::string variable_name); 
+
+        /**
+         *
+         */
+        void close(); 
+
+        /**
+         *
+         */
+        void fill();
+
+    private: 
+    
+        /** ROOT file to write ntuple to. */
+        TFile* file;
+
+        /** ROOT Tree. */
+        TTree* tree; 
+
+        /** Map containing ntuple variables */
+        std::map <std::string, double> variables; 
+
+        std::map <std::string, std::vector<double>> vectors; 
+        
+
+};
+
+#endif // __FLAT_TUPLE_MAKER_H__

--- a/analysis/include/HpsFitResult.h
+++ b/analysis/include/HpsFitResult.h
@@ -1,0 +1,166 @@
+/**
+ *
+ *
+ *
+ */
+
+#ifndef __HPS_FIT_RESULT_H__
+#define __HPS_FIT_RESULT_H__
+
+#include <TFitResult.h>
+#include <TFitResultPtr.h>
+
+class HpsFitResult { 
+
+    public: 
+
+        /** Default constructor */
+        HpsFitResult(); 
+
+        ~HpsFitResult(); 
+      
+        TFitResultPtr getBkgFitResult() { return bkg_result_; }; 
+        
+        TFitResultPtr getCompFitResult() { return comp_result_; }; 
+
+        void addLikelihood(double likelihood) { _likelihoods.push_back(likelihood); }
+
+        void addSignalYield(double signal_yield) { _signal_yields.push_back(signal_yield); }
+
+        double getCorrectedMass() const { return _cmass; }; 
+
+        /** @return _integral The integral within the fit window. */
+        double getIntegral() { return _integral; };
+
+        /** @return The mass hypothesis used for this fit. */
+        double getMass() const { return _mass; };
+
+        /** */
+        double getQ0() { return q0_; };
+
+        /** */
+        double getPValue() { return p_value_; };
+
+        /** @return The signal yield obstained from the sig+bkg fit. */
+        float getSignalYield() { return comp_result_->Parameter(poly_order_ + 1);  };
+         
+        /** @return The error on the signal yield. */
+        float getSignalYieldErr() { return comp_result_->ParError(poly_order_ + 1); }; 
+
+        /** */
+        double getUpperLimit() { return upper_limit_; };
+
+        double getUpperLimitPValue() { return _upper_limit_p_value; }; 
+
+        /** @return The size of the fit window used. */
+        double getWindowSize() { return this->window_size; }; 
+
+        std::vector<double> getLikelihoods() { return _likelihoods; }
+        
+        std::vector<double> getSignalYields() { return _signal_yields; }
+
+        //-------------//
+        //   Setters   //
+        //-------------//
+
+        void setIntegral(double integral) { _integral = integral; };
+
+        /** */
+        void setQ0(double q0) { q0_ = q0; };
+
+        /** */
+        void setPValue(double p_value) { p_value_ = p_value; };  
+        
+        /** 
+         * Set the result from the background only fit.
+         *
+         * @param result Result from the background only fit.
+         */
+        void setBkgFitResult(TFitResultPtr bkg_result) { bkg_result_ = bkg_result; };
+
+
+        /** 
+         * Set the result from the signal+background only fit.
+         *
+         * @param result Result from the signal+background only fit.
+         */
+        void setCompFitResult(TFitResultPtr comp_result) { comp_result_ = comp_result; };
+
+        /** 
+         * Set mass hypothesis used for this fit. 
+         * 
+         * @param mass The mass hypothesis. 
+         */
+        void setMass(double mass) { _mass = mass; };
+
+        /**
+         *
+         *
+         */
+        void setCorrectedMass(double cmass) { _cmass = cmass; }; 
+
+        /** 
+         * Set the order polynomial used by the fitter.
+         *
+         * @param poly_order Polynomial order used by the fitter.
+         */
+        void setPolyOrder(int poly_order) { poly_order_ = poly_order; };
+
+        /**
+         * Set the 2 sigma upper limit.
+         *
+         * @param upper_limit The 2 sigma upper limit.
+         */
+        void setUpperLimit(double upper_limit) { upper_limit_ = upper_limit; };
+
+        /** Set the p-value at the end of the upper limit calculation. */
+        void setUpperLimitPValue(double upper_limit_p_value) { _upper_limit_p_value = upper_limit_p_value; }
+
+        /**
+         * Set the size of the fit window used to get this results.
+         *
+         * @oaram window_size The size of the fit window.
+         */
+        void setWindowSize(double window_size) { this->window_size = window_size; }; 
+
+    private: 
+
+        /** Result from fit using a background model only. */
+        TFitResultPtr bkg_result_{nullptr}; 
+
+        /** Result from fit using a signal+background model. */
+        TFitResultPtr comp_result_{nullptr}; 
+
+        std::vector<double> _likelihoods; 
+
+        std::vector<double> _signal_yields; 
+
+        /** Total number of events within the fit window. */
+        double _integral{0};
+
+        /** Mass hypothesis. */
+        double _mass{0}; 
+
+        double _cmass{0}; 
+
+        /** q0 value */
+        double q0_;
+        
+        /** p-value. */
+        double p_value_;
+
+        /** Order polynomial used by the fitter. */
+        double poly_order_{0}; 
+
+        /** 2 sigma upper limit on the signal. */
+        double upper_limit_; 
+
+        /** p-value at the upper limit. */
+        double _upper_limit_p_value{-9999};
+
+        /*** Size of the fit window. */
+        double window_size;
+
+}; // HpsFitResult
+
+#endif // __HPS_FIT_RESULT_H__

--- a/analysis/src/BumpHunter.cxx
+++ b/analysis/src/BumpHunter.cxx
@@ -1,0 +1,493 @@
+
+/** 
+ * @file BumpHunter.cxx
+ * @brief
+ * @author Omar Moreno <omoreno1@ucsc.edu>
+ *         Santa Cruz Institute for Particle Physics
+ *         University of California, Santa Cruz
+ * @date January 14, 2015
+ *
+ */
+
+#include <BumpHunter.h>
+
+BumpHunter::BumpHunter(BkgModel model, int poly_order, int res_factor) 
+    : ofs(nullptr),
+      res_factor_(res_factor), 
+      poly_order_(poly_order) {
+
+}
+
+BumpHunter::~BumpHunter() {
+}
+
+void BumpHunter::initialize(TH1* histogram, double &mass_hypothesis) { 
+
+    mass_hypothesis_ = mass_hypothesis; 
+
+    // Shift the mass hypothesis so it sits in the middle of a bin.  
+    std::cout << "[ BumpHunter ]: Shifting mass hypothesis to nearest bin center " 
+              << mass_hypothesis << " ---> "; 
+    int mbin = histogram->GetXaxis()->FindBin(mass_hypothesis); 
+    mass_hypothesis = histogram->GetXaxis()->GetBinCenter(mbin);
+    std::cout << mass_hypothesis << " GeV" << std::endl;
+
+    // If the mass hypothesis is below the lower bound, throw an exception.  A 
+    // search cannot be performed using an invalid value for the mass hypothesis.
+    if (mass_hypothesis < lower_bound) {
+        throw std::runtime_error("Mass hypothesis less than the lower bound!"); 
+    }
+
+    // Correct the mass to take into account the mass scale systematic
+    corr_mass_ = this->correctMass(mass_hypothesis);
+
+    // Get the mass resolution at the corrected mass 
+    mass_resolution_ = this->getMassResolution(corr_mass_);
+    std::cout << "[ BumpHunter ]: Mass resolution: " << mass_resolution_ << " GeV" << std::endl;
+
+    // Calculate the fit window size
+    window_size_ = mass_resolution_*res_factor_;
+    this->printDebug("Window size: " + std::to_string(window_size_));
+
+    // Find the starting position of the window. This is set to the low edge of 
+    // the bin closest to the calculated value. If the start position falls 
+    // below the lower bound of the histogram, set it to the lower bound.
+    window_start_ = mass_hypothesis - window_size_/2;
+    int window_start_bin = histogram->GetXaxis()->FindBin(window_start_);  
+    window_start_ = histogram->GetXaxis()->GetBinLowEdge(window_start_bin);
+    if (window_start_ < lower_bound) { 
+        std::cout << "[ BumpHunter ]: Starting edge of window (" << window_start_ 
+                  << " MeV) is below lower bound." << std::endl;
+        window_start_bin = histogram->GetXaxis()->FindBin(lower_bound);
+        window_start_ = histogram->GetXaxis()->GetBinLowEdge(window_start_bin);
+    }
+    std::cout << "[ BumpHunter ]: Setting starting edge of fit window to " 
+              << window_start_ << " MeV." << std::endl;
+    
+    // Find the end position of the window.  This is set to the lower edge of 
+    // the bin closest to the calculated value. If the window edge falls above
+    // the upper bound of the histogram, set it to the upper bound.
+    // Furthermore, check that the bin serving as the upper boundary contains
+    // events. If the upper bound is shifted, reset the lower window bound.
+    window_end_ = window_start_ + window_size_;
+    int window_end_bin = histogram->GetXaxis()->FindBin(window_end_);
+    window_end_ = histogram->GetXaxis()->GetBinLowEdge(window_end_bin);
+    if (window_end_ > upper_bound_) { 
+        std::cout << "[ BumpHunter ]: Upper edge of window (" << window_end_ 
+                  << " MeV) is above upper bound." << std::endl;
+        window_end_bin = histogram->GetXaxis()->FindBin(upper_bound_);
+        
+        int last_bin_above = histogram->FindLastBinAbove(); 
+        if (window_end_bin > last_bin_above) window_end_bin = last_bin_above; 
+        
+        window_end_ = histogram->GetXaxis()->GetBinLowEdge(window_end_bin);
+        window_start_bin = histogram->GetXaxis()->FindBin(window_end_ - window_size_);  
+        window_start_ = histogram->GetXaxis()->GetBinLowEdge(window_start_bin);
+    }
+    std::cout << "[ BumpHunter ]: Setting upper edge of fit window to " 
+              << window_end_ << " MeV." << std::endl;
+
+    // Estimate the background normalization within the window by integrating
+    // the histogram within the window range.  This should be close to the 
+    // background yield in the case where there is no signal present.
+    integral_ = histogram->Integral(window_start_bin, window_end_bin);
+    this->printDebug("Window integral: " + std::to_string(integral_)); 
+}
+
+HpsFitResult* BumpHunter::performSearch(TH1* histogram, double mass_hypothesis, bool skip_bkg_fit, bool skip_ul) { 
+   
+    // Calculate all of the fit parameters e.g. window size, mass hypothesis
+    this->initialize(histogram, mass_hypothesis);
+
+    // Instantiate a new fit result object to store all of the results.
+    HpsFitResult* fit_result = new HpsFitResult(); 
+    fit_result->setPolyOrder(poly_order_); 
+
+    // If not fitting toys, start by performing a background only fit.
+    if (!skip_bkg_fit)  {
+         
+        // Start by performing a background only fit.  The results from this fit 
+        // are used to get an intial estimate of the background parameters.  
+        std::cout << "*************************************************" << std::endl;
+        std::cout << "*************************************************" << std::endl;
+        std::cout << "[ BumpHunter ]: Performing a background only fit." << std::endl;
+        std::cout << "*************************************************" << std::endl;
+        std::cout << "*************************************************" << std::endl;
+   
+        //
+        TF1* bkg{nullptr}; 
+        if (poly_order_ == 3) { 
+            
+            //
+            ExpPol3BkgFunction bkg_func(mass_hypothesis, window_end_ - window_start_); 
+            bkg = new TF1("bkg", bkg_func, -1, 1, 4);
+
+            //
+            bkg->SetParameters(4,0,0,0);
+            bkg->SetParNames("pol0","pol1","pol2","pol3");
+        } else { 
+            //
+            ExpPol5BkgFunction bkg_func(mass_hypothesis, window_end_ - window_start_); 
+            bkg = new TF1("bkg", bkg_func, -1, 1, 6);
+
+            //
+            bkg->SetParameters(4,0,0,0,0,0);
+            bkg->SetParNames("pol0","pol1","pol2","pol3","pol4","pol5");
+        }
+
+        TFitResultPtr result = histogram->Fit("bkg", "LES+", "", window_start_, window_end_); 
+        fit_result->setBkgFitResult(result); 
+        //result->Print();
+
+    }
+         
+    std::cout << "***************************************************" << std::endl;
+    std::cout << "***************************************************" << std::endl;
+    std::cout << "[ BumpHunter ]: Performing a signal+background fit." << std::endl;
+    std::cout << "***************************************************" << std::endl;
+    std::cout << "***************************************************" << std::endl;
+    
+    TF1* full{nullptr};  
+    if (poly_order_ == 3) { 
+        
+        ExpPol3FullFunction full_func(mass_hypothesis, window_end_ - window_start_); 
+        full = new TF1("full", full_func, -1, 1, 7);
+    
+        full->SetParameters(4,0,0,0,0,0,0);
+        full->SetParNames("pol0","pol1","pol2","pol3","signal norm","mean","sigma");
+        full->FixParameter(5,0.0); 
+        full->FixParameter(6, mass_resolution_); 
+  
+    } else { 
+  
+        ExpPol5FullFunction full_func(mass_hypothesis, window_end_ - window_start_); 
+        full = new TF1("full", full_func, -1, 1, 9);
+    
+        full->SetParameters(4,0,0,0,0,0,0,0,0);
+        full->SetParNames("pol0","pol1","pol2","pol3","pol4","pol5","signal norm","mean","sigma");
+        full->FixParameter(7,0.0); 
+        full->FixParameter(8, mass_resolution_); 
+
+    }    
+       
+    TFitResultPtr full_result = histogram->Fit("full", "LES+", "", window_start_, window_end_);
+    fit_result->setCompFitResult(full_result); 
+    //full_result->Print();
+
+    this->calculatePValue(fit_result);
+    std::cout << "[ BumpHunter ]: Bkg Fit Status: " << fit_result->getBkgFitResult()->IsValid() <<  std::endl;
+    std::cout << "[ BumpHunter ]: Full Fit Status: " << fit_result->getCompFitResult()->IsValid() <<  std::endl;
+    if((!skip_ul) && full_result->IsValid() ) this->getUpperLimit(histogram, fit_result);
+    
+    // Persist the mass hypothesis used for this fit
+    fit_result->setMass(mass_hypothesis_); 
+    
+    // Persist the mass after correcting for the mass scale
+    fit_result->setCorrectedMass(corr_mass_); 
+
+    // Set the window size 
+    fit_result->setWindowSize(window_size_);
+
+    // Set the total number of events within the window
+    fit_result->setIntegral(integral_);
+
+    return fit_result; 
+}
+
+void BumpHunter::calculatePValue(HpsFitResult* result) {
+
+    std::cout << "[ BumpHunter ]: Calculating p-value: " << std::endl;
+
+    //
+    double signal_yield = result->getCompFitResult()->Parameter(poly_order_ + 1); 
+    this->printDebug("Signal yield: " + std::to_string(signal_yield)); 
+
+    // In searching for a resonance, a signal is expected to lead to an 
+    // excess of events.  In this case, a signal yield of < 0 is  
+    // meaningless so we set the p-value = 1.  This follows the formulation
+    // put forth by Cowen et al. in https://arxiv.org/pdf/1007.1727.pdf. 
+    if (signal_yield <= 0) { 
+        result->setPValue(1);
+        this->printDebug("Signal yield is negative ... setting p-value = 1"); 
+        return; 
+    }
+
+    // Get the NLL obtained by minimizing the composite model with the signal
+    // yield floating.
+    double mle_nll = result->getCompFitResult()->MinFcnValue(); 
+    this->printDebug("NLL when mu = " + std::to_string(signal_yield) + ": " + std::to_string(mle_nll));
+
+    // Get the NLL obtained from the Bkg only fit.
+    double cond_nll = result->getBkgFitResult()->MinFcnValue(); 
+    printDebug("NLL when mu = 0: " + std::to_string(cond_nll));
+
+    // 1) Calculate the likelihood ratio which is chi2 distributed. 
+    // 2) From the chi2, calculate the p-value.
+    double q0 = 0; 
+    double p_value = 0; 
+    this->getChi2Prob(cond_nll, mle_nll, q0, p_value);  
+
+    std::cout << "[ BumpHunter ]: p-value: " << p_value << std::endl;
+    
+    // Update the result
+    result->setPValue(p_value);
+    result->setQ0(q0);  
+    
+}
+
+void BumpHunter::printDebug(std::string message) { 
+    std::cout << "[ BumpHunter ]: " << message << std::endl;
+    //if (debug) std::cout << "[ BumpHunter ]: " << message << std::endl;
+}
+
+void BumpHunter::getUpperLimit(TH1* histogram, HpsFitResult* result) {
+    
+    TF1* comp{nullptr};
+    if (poly_order_ == 3) { 
+  
+        ExpPol3FullFunction comp_func(mass_hypothesis_, window_end_ - window_start_); 
+        comp = new TF1("comp_ul", comp_func, -1, 1, 7);
+    
+        comp->SetParameters(4,0,0,0,0,0,0);
+        comp->SetParNames("pol0","pol1","pol2","pol3","signal norm","mean","sigma");
+        comp->FixParameter(5,0.0); 
+        comp->FixParameter(6, mass_resolution_); 
+        
+    } else { 
+       
+        ExpPol5FullFunction comp_func(mass_hypothesis_, window_end_ - window_start_); 
+        comp = new TF1("comp_ul", comp_func, -1, 1, 9);
+    
+        comp->SetParameters(4,0,0,0,0,0,0,0,0);
+        comp->SetParNames("pol0","pol1","pol2","pol3","pol4","pol5","signal norm","mean","sigma");
+        comp->FixParameter(7,0.0); 
+        comp->FixParameter(8, mass_resolution_);
+   
+    }    
+
+    std::cout << "Mass resolution: " << mass_resolution_ << std::endl; 
+    std::cout << "[ BumpHunter ]: Calculating upper limit." << std::endl;
+
+    //  Get the signal yield obtained from the signal+bkg fit
+    double signal_yield = result->getCompFitResult()->Parameter(poly_order_ + 1); 
+    this->printDebug("Signal yield: " + std::to_string(signal_yield)); 
+
+    // Get the minimum NLL value that will be used for testing upper limits.
+    // If the signal yield (mu estimator) at the min NLL is < 0, use the NLL
+    // obtained when mu = 0.
+    double mle_nll = result->getCompFitResult()->MinFcnValue(); 
+
+    if (signal_yield < 0) {
+        this->printDebug("Signal yield @ min NLL is < 0. Using NLL when signal yield = 0");
+
+        // Get the NLL obtained assuming the background only hypothesis
+        mle_nll = result->getBkgFitResult()->MinFcnValue(); 
+        
+        signal_yield = 0;
+    } 
+    this->printDebug("MLE NLL: " + std::to_string(mle_nll));   
+
+    signal_yield = floor(signal_yield) + 1; 
+
+    double p_value = 1;
+    double q0 = 0; 
+    while(true) {
+       
+        this->printDebug("Setting signal yield to: " + std::to_string(signal_yield));
+        //std::cout << "[ BumpHunter ]: Current p-value: " << p_value << std::endl;
+        comp->FixParameter(poly_order_ + 1, signal_yield); 
+        
+        TFitResultPtr full_result 
+            = histogram->Fit("comp_ul", "LES+", "", window_start_, window_end_);
+        double cond_nll = full_result->MinFcnValue(); 
+
+        // 1) Calculate the likelihood ratio which is chi2 distributed. 
+        // 2) From the chi2, calculate the p-value.
+        this->getChi2Prob(cond_nll, mle_nll, q0, p_value);  
+
+        this->printDebug("p-value after fit : " + std::to_string(p_value)); 
+        std::cout << "[ BumpHunter ]: Current Signal Yield: " << signal_yield << std::endl;
+        std::cout << "[ BumpHunter ]: Current p-value: " << p_value << std::endl;
+        
+        if ((p_value <= 0.0455 && p_value > 0.044)) { 
+            
+            std::cout << "[ BumpHunter ]: Upper limit: " << signal_yield << std::endl;
+            std::cout << "[ BumpHunter ]: p-value: " << p_value << std::endl;
+
+            result->setUpperLimit(signal_yield);
+            result->setUpperLimitPValue(p_value); 
+     
+            break; 
+        } 
+        else if (signal_yield <= 0 && p_value < 0.044) 
+        {
+            std::cout << "[ BumpHunter ]: Caution Background Model suspicious!" << std::endl;
+            std::cout << "[ BumpHunter ]: Upper limit: " << signal_yield << std::endl;
+            std::cout << "[ BumpHunter ]: p-value: " << p_value << std::endl;
+
+            result->setUpperLimit(signal_yield);
+            result->setUpperLimitPValue(p_value); 
+     
+            break; 
+        }
+        else if (p_value <= 0.044) signal_yield -= 1;
+        else if (p_value <= 0.059) signal_yield += 10;
+        else if (p_value <= 0.10) signal_yield += 20;
+        else if (p_value <= 0.2) signal_yield += 40; 
+        else signal_yield += 100;  
+    }
+}
+
+std::vector<TH1*> BumpHunter::generateToys(TH1* histogram, double n_toys, int seed) { 
+
+    gRandom->SetSeed(seed); 
+
+    TF1* bkg = histogram->GetFunction("bkg"); 
+
+    std::vector<TH1*> hists;
+    for (int itoy = 0; itoy < n_toys; ++itoy) { 
+        std::string name = "invariant_mas_" + std::to_string(itoy); 
+        if(itoy%100 == 0) std::cout << "Generating Toy " << itoy << std::endl;
+        TH1F* hist = new TH1F(name.c_str(), name.c_str(), histogram->GetNbinsX(), 0., 0.15);
+        for (int i =0; i < integral_; ++i) { 
+            hist->Fill(bkg->GetRandom(window_start_, window_end_)); 
+        }
+        hists.push_back(hist); 
+    }
+
+    return hists;
+}
+
+
+void BumpHunter::getChi2Prob(double cond_nll, double mle_nll, double &q0, double &p_value) {
+   
+
+    this->printDebug("Cond NLL: " + std::to_string(cond_nll)); 
+    this->printDebug("Uncod NLL: " + std::to_string(mle_nll));  
+    double diff = cond_nll - mle_nll;
+    this->printDebug("Delta NLL: " + std::to_string(diff));
+    
+    q0 = 2*diff;
+    this->printDebug("q0: " + std::to_string(q0));
+    
+    p_value = ROOT::Math::chisquared_cdf_c(q0, 1);
+    this->printDebug("p-value before dividing: " + std::to_string(p_value));  
+    p_value *= 0.5;
+    this->printDebug("p-value: " + std::to_string(p_value)); 
+}
+
+void BumpHunter::setBounds(double lower_bound, double upper_bound) {
+    lower_bound = lower_bound; 
+    upper_bound_ = upper_bound;
+    printf("Fit bounds set to [ %f , %f ]\n", lower_bound, upper_bound_);   
+}
+
+double BumpHunter::correctMass(double mass) { 
+    double offset = -1.19892320e4*pow(mass, 3) + 1.50196798e3*pow(mass,2) 
+                    - 8.38873712e1*mass + 6.23215746; 
+    offset /= 100; 
+    this->printDebug("Offset: " + std::to_string(offset)); 
+    double cmass = mass - mass*offset; 
+    this->printDebug("Corrected Mass: " + std::to_string(cmass)); 
+    return cmass;
+}
+
+/**
+ * BkgFunction
+ */
+
+//
+// TODO: Move the classes externally
+//
+
+ExpPol3BkgFunction::ExpPol3BkgFunction(double mass_hypothesis, double window_size)
+    : mass_hypothesis_(mass_hypothesis), 
+      window_size_(window_size) { 
+}
+
+double ExpPol3BkgFunction::operator() (double* x, double* par) { 
+    
+    double xp = (x[0] - mass_hypothesis_)/(window_size_*2.0); 
+  
+    // Chebyshevs between given limits
+    double t0 = par[0];
+    double t1 = par[1]*xp;
+    double t2 = par[2]*(2*xp*xp - 1);
+    double t3 = par[3]*(4*xp*xp*xp - 3*xp);
+  
+    double pol = t0+t1+t2+t3;
+
+    return TMath::Power(10,pol);
+}
+
+ExpPol5BkgFunction::ExpPol5BkgFunction(double mass_hypothesis, double window_size)
+    : mass_hypothesis_(mass_hypothesis), 
+      window_size_(window_size) { 
+}
+
+double ExpPol5BkgFunction::operator() (double* x, double* par) { 
+    
+    double xp = (x[0] - mass_hypothesis_)/(window_size_*2.0); 
+  
+    // Chebyshevs between given limits
+    double t0 = par[0];
+    double t1 = par[1]*xp;
+    double t2 = par[2]*(2*xp*xp - 1);
+    double t3 = par[3]*(4*xp*xp*xp - 3*xp);
+    double t4 = par[4]*(8*xp*xp*xp*xp - 8*xp*xp + 1);
+    double t5 = par[5]*(16*xp*xp*xp*xp*xp - 20*xp*xp*xp + 5*xp);
+  
+    double pol = t0+t1+t2+t3+t4+t5;
+
+    return TMath::Power(10,pol);
+}
+
+ExpPol3FullFunction::ExpPol3FullFunction(double mass_hypothesis, double window_size)
+    : mass_hypothesis_(mass_hypothesis), 
+      window_size_(window_size) { 
+}
+
+
+double ExpPol3FullFunction::operator() (double* x, double* par) { 
+    
+    double xp = (x[0] - mass_hypothesis_)/(window_size_*2.0); 
+  
+    // Chebyshevs between given limits
+    double t0 = par[0];
+    double t1 = par[1]*xp;
+    double t2 = par[2]*(2*xp*xp - 1);
+    double t3 = par[3]*(4*xp*xp*xp - 3*xp);
+  
+    double pol = t0+t1+t2+t3;
+
+    double gauss = (1.0)/(sqrt(2.0*TMath::Pi()*pow(par[6],2))) *
+        TMath::Exp( - pow((xp-par[5]),2)/(2.0*pow(par[6],2)) );
+  
+    return TMath::Power(10,pol)+0.0001*par[4]*gauss;
+}
+
+ExpPol5FullFunction::ExpPol5FullFunction(double mass_hypothesis, double window_size)
+    : mass_hypothesis_(mass_hypothesis), 
+      window_size_(window_size) { 
+}
+
+
+double ExpPol5FullFunction::operator() (double* x, double* par) { 
+    
+    double xp = (x[0] - mass_hypothesis_)/(window_size_*2.0); 
+  
+    // Chebyshevs between given limits
+    double t0 = par[0];
+    double t1 = par[1]*xp;
+    double t2 = par[2]*(2*xp*xp - 1);
+    double t3 = par[3]*(4*xp*xp*xp - 3*xp);
+    double t4 = par[4]*(8*xp*xp*xp*xp - 8*xp*xp + 1);
+    double t5 = par[5]*(16*xp*xp*xp*xp*xp - 20*xp*xp*xp + 5*xp);
+  
+    double pol = t0+t1+t2+t3+t4+t5;
+
+    double gauss = (1.0)/(sqrt(2.0*TMath::Pi()*pow(par[8],2))) *
+        TMath::Exp( - pow((xp-par[7]),2)/(2.0*pow(par[8],2)) );
+  
+    return TMath::Power(10,pol)+0.0001*par[6]*gauss;
+}

--- a/analysis/src/BumpHunter.cxx
+++ b/analysis/src/BumpHunter.cxx
@@ -34,7 +34,7 @@ void BumpHunter::initialize(TH1* histogram, double &mass_hypothesis) {
 
     // If the mass hypothesis is below the lower bound, throw an exception.  A 
     // search cannot be performed using an invalid value for the mass hypothesis.
-    if (mass_hypothesis < lower_bound) {
+    if (mass_hypothesis < lower_bound_) {
         throw std::runtime_error("Mass hypothesis less than the lower bound!"); 
     }
 
@@ -55,10 +55,10 @@ void BumpHunter::initialize(TH1* histogram, double &mass_hypothesis) {
     window_start_ = mass_hypothesis - window_size_/2;
     int window_start_bin = histogram->GetXaxis()->FindBin(window_start_);  
     window_start_ = histogram->GetXaxis()->GetBinLowEdge(window_start_bin);
-    if (window_start_ < lower_bound) { 
+    if (window_start_ < lower_bound_) { 
         std::cout << "[ BumpHunter ]: Starting edge of window (" << window_start_ 
                   << " MeV) is below lower bound." << std::endl;
-        window_start_bin = histogram->GetXaxis()->FindBin(lower_bound);
+        window_start_bin = histogram->GetXaxis()->FindBin(lower_bound_);
         window_start_ = histogram->GetXaxis()->GetBinLowEdge(window_start_bin);
     }
     std::cout << "[ BumpHunter ]: Setting starting edge of fit window to " 
@@ -348,7 +348,7 @@ std::vector<TH1*> BumpHunter::generateToys(TH1* histogram, double n_toys, int se
     for (int itoy = 0; itoy < n_toys; ++itoy) { 
         std::string name = "invariant_mas_" + std::to_string(itoy); 
         if(itoy%100 == 0) std::cout << "Generating Toy " << itoy << std::endl;
-        TH1F* hist = new TH1F(name.c_str(), name.c_str(), histogram->GetNbinsX(), 0., 0.15);
+        TH1F* hist = new TH1F(name.c_str(), name.c_str(), histogram->GetNbinsX(), window_start_, window_end_);
         for (int i =0; i < integral_; ++i) { 
             hist->Fill(bkg->GetRandom(window_start_, window_end_)); 
         }
@@ -377,9 +377,9 @@ void BumpHunter::getChi2Prob(double cond_nll, double mle_nll, double &q0, double
 }
 
 void BumpHunter::setBounds(double lower_bound, double upper_bound) {
-    lower_bound = lower_bound; 
+    lower_bound_ = lower_bound; 
     upper_bound_ = upper_bound;
-    printf("Fit bounds set to [ %f , %f ]\n", lower_bound, upper_bound_);   
+    printf("Fit bounds set to [ %f , %f ]\n", lower_bound_, upper_bound_);   
 }
 
 double BumpHunter::correctMass(double mass) { 

--- a/analysis/src/FlatTupleMaker.cxx
+++ b/analysis/src/FlatTupleMaker.cxx
@@ -1,0 +1,70 @@
+/*
+ * @file FlatTupleMaker.cxx
+ * @author Omar Moreno
+ * @date January 18, 2016
+ * @brief 
+ *
+ */
+
+#include <FlatTupleMaker.h>
+
+FlatTupleMaker::FlatTupleMaker(std::string file_name, std::string tree_name) { 
+
+    file = new TFile(file_name.c_str(), "RECREATE");
+
+    tree = new TTree(tree_name.c_str(), tree_name.c_str());   
+    
+}
+
+FlatTupleMaker::~FlatTupleMaker() { 
+    delete file; 
+    delete tree; 
+}
+
+void FlatTupleMaker::addVariable(std::string variable_name) { 
+    
+    // Set the default value of the variable to something unrealistic 
+    variables[variable_name] = -9999;
+    
+    // Add a leaf to the ROOT tree and set its address to the address of the 
+    // newly created variable. 
+    tree->Branch(variable_name.c_str(), &variables[variable_name], (variable_name + "/D").c_str()); 
+}
+
+void FlatTupleMaker::addVector(std::string variable_name) { 
+    vectors[variable_name] = {}; 
+    tree->Branch(variable_name.c_str(), &vectors[variable_name]); 
+}
+
+void FlatTupleMaker::addToVector(std::string variable_name, double value) {
+    vectors[variable_name].push_back(value); 
+}
+
+bool FlatTupleMaker::hasVariable(std::string variable_name) { 
+    
+    auto search = variables.find(variable_name); 
+    if (search != variables.end()) return true; 
+
+    return false; 
+}
+
+void FlatTupleMaker::close() { 
+    file->Write();
+    file->Close(); 
+}
+
+
+void FlatTupleMaker::fill() { 
+    
+    // Fill the event with the current variables.
+    tree->Fill();
+
+    // Reset the variables to their original values
+    for (auto& element : variables) { 
+        element.second = -9999; 
+    }
+    
+    for (auto& element : vectors) { 
+        element.second.clear();
+    }
+}

--- a/analysis/src/HpsFitResult.cxx
+++ b/analysis/src/HpsFitResult.cxx
@@ -1,0 +1,12 @@
+
+#include <HpsFitResult.h>
+
+HpsFitResult::HpsFitResult() 
+    : 
+      q0_(0),  
+      p_value_(0),
+      upper_limit_(0) { 
+}
+
+HpsFitResult::~HpsFitResult() { 
+}

--- a/processing/include/ConfigurePython.h
+++ b/processing/include/ConfigurePython.h
@@ -54,6 +54,13 @@ class ConfigurePython {
 
     private: 
 
+        /** The run mode of the process:
+         *  0: LCIO to ROOT
+         *  1: ROOT to Histo
+         *  2: Histo Analysis
+         * */
+        int run_mode_{-1};
+
         /** The maximum number of events to process, if provided in python file. */
         int event_limit_{-1};
 

--- a/processing/include/Process.h
+++ b/processing/include/Process.h
@@ -2,6 +2,7 @@
  * @file Process.h
  * @brief Class which represents the process under execution.
  * @author Omar Moreno, SLAC National Accelerator Laboratory
+ * @author Cameron Bravo, SLAC National Accelerator Laboratory
  */
 
 #ifndef __PROCESS_H__
@@ -56,33 +57,51 @@ class Process {
         void addOutputFileName(const std::string& output_filename);
 
         /**
+         * Set the run mode of the process.
+         * @param run_mode Maximum number of events to process.  
+         *     0 indicates LCIO to ROOT.
+         *     1 indicates ROOT to Histo.
+         *     2 indicates Histo Analysis.
+         */
+        void setRunMode(int run_mode=-1) {
+            run_mode_ = run_mode;
+        }
+
+        /**
          * Set the maximum number of events to process.  Processing will stop 
          * when either there are no more input events or when this number of events have been processed.
          * @param event_limit Maximum number of events to process.  -1 indicates no limit.
          */
         void setEventLimit(int event_limit=-1) {
-            event_limit_=event_limit;
+            event_limit_ = event_limit;
         }
 
-        /** Run the process. */
+        /**
+         * Get the run mode of the process.
+         */
+        int getRunMode() {
+            return run_mode_;
+        }
+
+        /** Run the LCIO to ROOT process. */
         void run();
 
-        /** Run the process on root files. */
-        //TODO Write this better
+        /** Run the ROOT to Histo process. */
         void runOnRoot();
 
+        /** Run the Histo Analysis process. */
+        void runOnHisto();
+
         /** Request that the processing finish with this event. */ 
-        void requestFinish() { event_limit_=0; }
-
-        //TODO add a check on consistent extensions of the input files
-        /** Check if the input_files_ are rootFiles  */
-       bool processRootFiles();
-
+        void requestFinish() { event_limit_ = 0; }
 
     private:
 
         /** Reader used to parse either binary or EVIO files. */
         //DataRead* data_reader{nullptr}; 
+
+        /** Run mode of the process. */
+        int run_mode_{-1};
 
         /** Limit on events to process. */
         int event_limit_{-1};

--- a/processing/include/Processor.h
+++ b/processing/include/Processor.h
@@ -68,10 +68,23 @@ class Processor {
         virtual void initialize(TTree* tree) = 0;
 
         /**
+         * Callback for the Processor to take any necessary
+         * action when the processing of events starts, such as
+         * initializing files.
+         */
+        virtual void initialize(std::string inFilename, std::string outFilename) {};
+
+        /**
          * Set output TFile for AnaProcessors
          * @param pointer to output TFile
          */
         virtual void setFile(TFile* outFile) {outF_ = outFile;};
+
+        /**
+         * Process the histograms and generate analysis output.
+         * @return status of the processing.
+         */
+        virtual bool process() {return true;};
 
         /**
          * Process the event and put new data products into it.

--- a/processing/src/ConfigurePython.cxx
+++ b/processing/src/ConfigurePython.cxx
@@ -128,6 +128,7 @@ ConfigurePython::ConfigurePython(const std::string& python_script, char* args[],
     }
 
     event_limit_ = intMember(p_process, "max_events");
+    run_mode_    = intMember(p_process, "run_mode");
 
     PyObject* p_sequence = PyObject_GetAttrString(p_process, "sequence");
     if (!PyList_Check(p_sequence)) {
@@ -319,6 +320,7 @@ Process* ConfigurePython::makeProcess() {
     }
 
     p->setEventLimit(event_limit_);
+    p->setRunMode(run_mode_);
 
     return p; 
 }

--- a/processing/src/Process.cxx
+++ b/processing/src/Process.cxx
@@ -16,58 +16,23 @@ Process::Process() {}
 
 void Process::runOnHisto() {
     try {
-        std::cout << "TODO: Write Histo Analysis Process" << std::endl;
-        /*int n_events_processed = 0;
-        HpsEvent event;
-        TH1D * event_h = new TH1D("event_h","Number of Events Processed;;Events", 21, -10.5, 10.5);
-        int cfile =0 ;
+        int cfile = 0;
         for (auto ifile : input_files_) {
-            std::cout<<"Processing file"<<ifile<<std::endl;
-            HpsEventFile* file(nullptr);
-            if (!output_files_.empty()) {
-                file = new HpsEventFile(ifile, output_files_[cfile]);
-                file->setupEvent(&event);
-            }
-            for (auto module : sequence_) {
-                module->initialize(event.getTree());
-                module->setFile(file->getOutputFile());
-            }
-            while (file->nextEvent() && (event_limit_ < 0 || (n_events_processed < event_limit_))) {
-                if (n_events_processed%1000 == 0)
-                    std::cout<<"Event:"<<n_events_processed<<std::endl;
+            std::cout << "Processing file " << ifile << std::endl;
 
-                //In this way if the processing fails (like an event doesn't pass the selection, the other modules aren't run on that event)
-                for (auto module : sequence_) {
-                    module->process(&event);
-                }
-                //event.Clear();
-                event_h->Fill(0.0);
-                ++n_events_processed;
+            for (auto module : sequence_) {
+                module->initialize(ifile, output_files_[cfile]);
+                module->process();
+                module->finalize();
             }
             //Pass to next file
             ++cfile;
-            // Finalize all modules
 
-            //Select the output file for storing the results of the processors.
-            file->resetOutputFileDir();
-            event_h->Write();
-            for (auto module : sequence_) {
-                //TODO:Change the finalize method
-                module->finalize();
-            }
-            // TODO Check all these destructors
-            if (file) {
-                file->close();
-                delete file;
-                file = nullptr;
-                delete event_h;
-                event_h = nullptr;
-            }
-        }*/
+        } //ifile
     } catch (std::exception& e) {
         std::cerr<<"Error:"<<e.what()<<std::endl;
     }
-}
+} //Process::runOnHisto
 
 void Process::runOnRoot() {
     try {

--- a/processing/src/Process.cxx
+++ b/processing/src/Process.cxx
@@ -14,11 +14,59 @@ Process::Process() {}
 
 //TODO Fix this better
 
-bool Process::processRootFiles() {
-    if ((input_files_[0]).find(".root") != std::string::npos)
-        return true;
+void Process::runOnHisto() {
+    try {
+        std::cout << "TODO: Write Histo Analysis Process" << std::endl;
+        /*int n_events_processed = 0;
+        HpsEvent event;
+        TH1D * event_h = new TH1D("event_h","Number of Events Processed;;Events", 21, -10.5, 10.5);
+        int cfile =0 ;
+        for (auto ifile : input_files_) {
+            std::cout<<"Processing file"<<ifile<<std::endl;
+            HpsEventFile* file(nullptr);
+            if (!output_files_.empty()) {
+                file = new HpsEventFile(ifile, output_files_[cfile]);
+                file->setupEvent(&event);
+            }
+            for (auto module : sequence_) {
+                module->initialize(event.getTree());
+                module->setFile(file->getOutputFile());
+            }
+            while (file->nextEvent() && (event_limit_ < 0 || (n_events_processed < event_limit_))) {
+                if (n_events_processed%1000 == 0)
+                    std::cout<<"Event:"<<n_events_processed<<std::endl;
 
-    return false;
+                //In this way if the processing fails (like an event doesn't pass the selection, the other modules aren't run on that event)
+                for (auto module : sequence_) {
+                    module->process(&event);
+                }
+                //event.Clear();
+                event_h->Fill(0.0);
+                ++n_events_processed;
+            }
+            //Pass to next file
+            ++cfile;
+            // Finalize all modules
+
+            //Select the output file for storing the results of the processors.
+            file->resetOutputFileDir();
+            event_h->Write();
+            for (auto module : sequence_) {
+                //TODO:Change the finalize method
+                module->finalize();
+            }
+            // TODO Check all these destructors
+            if (file) {
+                file->close();
+                delete file;
+                file = nullptr;
+                delete event_h;
+                event_h = nullptr;
+            }
+        }*/
+    } catch (std::exception& e) {
+        std::cerr<<"Error:"<<e.what()<<std::endl;
+    }
 }
 
 void Process::runOnRoot() {

--- a/processing/src/hpstr.cxx
+++ b/processing/src/hpstr.cxx
@@ -2,6 +2,7 @@
  *  @file   hpstr.cxx
  *  @brief  App used to create and analyze HPS DST files.
  *  @author Omar Moreno, SLAC National Accelerator Laboratory
+ *  @author Cameron Bravo, SLAC National Accelerator Laboratory
  */
 
 //----------------//
@@ -51,8 +52,9 @@ int main(int argc, char **argv) {
         std::cout << "---- [ hpstr ]: Configuration load complete  --------" << std::endl;
 
         Process* p = cfg.makeProcess();
+        int run_mode = p->getRunMode();
 
-        std::cout << "---- [ hpstr ]: Process initialized.  --------" << std::endl;
+        std::cout << "---- [ hpstr ]: Process mode " << run_mode << " initialized.  --------" << std::endl;
 
         // If Ctrl-c is used, immediately exit the application.
         struct sigaction act;
@@ -62,16 +64,27 @@ int main(int argc, char **argv) {
             return 1;
         }
 
-        std::cout << "---- [ hpstr ]: Starting event processing --------" << std::endl;
+        std::cout << "---- [ hpstr ]: Start of processing --------" << std::endl;
 
         //TODO Make this better
-        if (p->processRootFiles()) {
-            std::cout<<"---- [ hpstr ]: Running on ROOT Files --------" << std::endl;
+        if (run_mode == 0) 
+        {
+            std::cout<<"---- [ hpstr ]: Running LCIO -> ROOT Process --------" << std::endl;
+            p->run();
+        }
+        else if (run_mode == 1) 
+        {
+            std::cout<<"---- [ hpstr ]: Running ROOT -> Histo Process --------" << std::endl;
             p->runOnRoot();
         }
-        else {
-            std::cout<<"---- [ hpstr ]: Running on LCIO Files --------" << std::endl;
-            p->run();
+        else if (run_mode == 2)
+        {
+            std::cout<<"---- [ hpstr ]: Running Histo Analysis Process --------" << std::endl;
+            p->runOnHisto();
+        }
+        else 
+        {
+            std::cout<<"---- [ hpstr ]: Run Mode " << run_mode << " does not exist! --------" << std::endl;
         }
 
         std::cout << "---- [ hpstr ]: Event processing complete  --------" << std::endl;

--- a/processors/config/anaMCTuple_cfg.py
+++ b/processors/config/anaMCTuple_cfg.py
@@ -11,6 +11,9 @@ print 'Output file: %s' % outfile
 
 p = HpstrConf.Process()
 
+p.run_mode = 1
+#p.max_events = 1000
+
 # Library containing processors
 p.libraries.append("libprocessors.so")
 
@@ -36,7 +39,5 @@ p.sequence = [mcana]
 
 p.input_files=[infile]
 p.output_files = [outfile]
-
-#p.max_events = 1000
 
 p.printProcess()

--- a/processors/config/anaRecoTuple_cfg.py
+++ b/processors/config/anaRecoTuple_cfg.py
@@ -11,6 +11,9 @@ print 'Output file: %s' % outfile
 
 p = HpstrConf.Process()
 
+p.run_mode = 1
+#p.max_events = 1000
+
 # Library containing processors
 p.libraries.append("libprocessors.so")
 
@@ -37,7 +40,5 @@ p.sequence = [recoana]
 
 p.input_files=[infile]
 p.output_files = [outfile]
-
-#p.max_events = 1000
 
 p.printProcess()

--- a/processors/config/anaTrackTuple_cfg.py
+++ b/processors/config/anaTrackTuple_cfg.py
@@ -11,6 +11,9 @@ print('Output file: %s' % outFilename)
 
 p = HpstrConf.Process()
 
+p.run_mode = 1
+#p.max_events = 1000
+
 # Library containing processors
 p.libraries.append("libprocessors.so")
 
@@ -31,7 +34,5 @@ p.sequence = [anaTrks]
 
 p.input_files=[inFilename]
 p.output_files = [outFilename]
-
-#p.max_events = 1000
 
 p.printProcess()

--- a/processors/config/bhToys_cfg.py
+++ b/processors/config/bhToys_cfg.py
@@ -1,9 +1,29 @@
 import HpstrConf
 import sys
 
+from optparse import OptionParser
+
+parser = OptionParser()
+parser.add_option("-i", "--inFile", type="string", dest="inFilename",
+        help="Input filename.", metavar="inFilename", default="cutflows.root")
+parser.add_option("-m", "--mass", type="int", dest="mass_hypo",
+        help="Mass hypothesis in MeV.", metavar="mass_hypo", default=95)
+parser.add_option("-p", "--poly", type="int", dest="poly_order",
+        help="Polynomial order of background model.", metavar="poly_order", default=3)
+parser.add_option("-w", "--win", type="int", dest="win_factor",
+        help="Window factor for determining fit window size.", metavar="win_factor", default=11)
+parser.add_option("-s", "--spec", type="string", dest="mass_spec",
+        help="Name of mass spectrum histogram.", metavar="mass_spec", 
+        default="mass_tweak__p_tot_min_cut")
+
+(options, args) = parser.parse_args()
+
 # Use the input file to set the output file name
-histo_file = sys.argv[1].strip()
-toy_file = '%s_bhToys.root' % histo_file[:-5]
+histo_file = options.inFilename
+mass_hypo = options.mass_hypo/1000.0
+poly_order = options.poly_order
+win_factor = options.win_factor
+toy_file = 'bhToys_m%iw%ip%i.root'%(mass_hypo, win_factor, poly_order)
 
 print('Histo file: %s' % histo_file)
 print('Toy file: %s' % toy_file)
@@ -27,9 +47,9 @@ bhtoys = HpstrConf.Processor('bhtoys', 'BhToysHistoProcessor')
 ###############################
 #MCParticles
 bhtoys.parameters["debug"] = 1 
-bhtoys.parameters["massSpectrum"] = 'mass_tweak__p_tot_min_cut'
-bhtoys.parameters["mass_hypo"] = 95.0/1000.0
-bhtoys.parameters["poly_order"] = 3
+bhtoys.parameters["massSpectrum"] = options.mass_spec
+bhtoys.parameters["mass_hypo"] = mass_hypo
+bhtoys.parameters["poly_order"] = poly_order
 bhtoys.parameters["win_factor"] = 12
 bhtoys.parameters["seed"] = 0
 bhtoys.parameters["nToys"] = 100

--- a/processors/config/bhToys_cfg.py
+++ b/processors/config/bhToys_cfg.py
@@ -6,12 +6,16 @@ from optparse import OptionParser
 parser = OptionParser()
 parser.add_option("-i", "--inFile", type="string", dest="inFilename",
         help="Input filename.", metavar="inFilename", default="cutflows.root")
+parser.add_option("-d", "--outDir", type="string", dest="outDir",
+        help="Specify the output directory.", metavar="outDir", default=".")
 parser.add_option("-m", "--mass", type="int", dest="mass_hypo",
-        help="Mass hypothesis in MeV.", metavar="mass_hypo", default=95)
+        help="Mass hypothesis in MeV.", metavar="mass_hypo", default=145)
 parser.add_option("-p", "--poly", type="int", dest="poly_order",
         help="Polynomial order of background model.", metavar="poly_order", default=3)
 parser.add_option("-w", "--win", type="int", dest="win_factor",
         help="Window factor for determining fit window size.", metavar="win_factor", default=11)
+parser.add_option("-t", "--toys", type="int", dest="nToys",
+        help="Number of toy spectra to throw.", metavar="nToys", default=100)
 parser.add_option("-s", "--spec", type="string", dest="mass_spec",
         help="Name of mass spectrum histogram.", metavar="mass_spec", 
         default="mass_tweak__p_tot_min_cut")
@@ -23,7 +27,7 @@ histo_file = options.inFilename
 mass_hypo = options.mass_hypo/1000.0
 poly_order = options.poly_order
 win_factor = options.win_factor
-toy_file = 'bhToys_m%iw%ip%i.root'%(mass_hypo, win_factor, poly_order)
+toy_file = '%s/bhToys_m%iw%ip%i.root'%(options.outDir, options.mass_hypo, win_factor, poly_order)
 
 print('Histo file: %s' % histo_file)
 print('Toy file: %s' % toy_file)
@@ -50,9 +54,9 @@ bhtoys.parameters["debug"] = 1
 bhtoys.parameters["massSpectrum"] = options.mass_spec
 bhtoys.parameters["mass_hypo"] = mass_hypo
 bhtoys.parameters["poly_order"] = poly_order
-bhtoys.parameters["win_factor"] = 12
+bhtoys.parameters["win_factor"] = win_factor
 bhtoys.parameters["seed"] = 0
-bhtoys.parameters["nToys"] = 100
+bhtoys.parameters["nToys"] = options.nToys
 
 # Sequence which the processors will run.
 p.sequence = [bhtoys]

--- a/processors/config/bhToys_cfg.py
+++ b/processors/config/bhToys_cfg.py
@@ -27,9 +27,12 @@ bhtoys = HpstrConf.Processor('bhtoys', 'BhToysHistoProcessor')
 ###############################
 #MCParticles
 bhtoys.parameters["debug"] = 1 
-bhtoys.parameters["massSpectrum"] = 'massDataHisto_h'
-bhtoys.parameters["pol_order"] = 3
-bhtoys.parameters["mass_hypo"] = 95.0
+bhtoys.parameters["massSpectrum"] = 'mass_tweak__p_tot_min_cut'
+bhtoys.parameters["mass_hypo"] = 95.0/1000.0
+bhtoys.parameters["poly_order"] = 3
+bhtoys.parameters["win_factor"] = 12
+bhtoys.parameters["seed"] = 0
+bhtoys.parameters["nToys"] = 100
 
 # Sequence which the processors will run.
 p.sequence = [bhtoys]

--- a/processors/config/bhToys_cfg.py
+++ b/processors/config/bhToys_cfg.py
@@ -1,0 +1,40 @@
+import HpstrConf
+import sys
+
+# Use the input file to set the output file name
+histo_file = sys.argv[1].strip()
+toy_file = '%s_bhToys.root' % histo_file[:-5]
+
+print('Histo file: %s' % histo_file)
+print('Toy file: %s' % toy_file)
+
+p = HpstrConf.Process()
+
+p.run_mode = 2
+#p.max_events = 1000
+
+# Library containing processors
+p.libraries.append("libprocessors.so")
+
+###############################
+#          Processors         #
+###############################
+
+bhtoys = HpstrConf.Processor('bhtoys', 'BhToysHistoProcessor')
+
+###############################
+#   Processor Configuration   #
+###############################
+#MCParticles
+bhtoys.parameters["debug"] = 1 
+bhtoys.parameters["massSpectrum"] = 'massDataHisto_h'
+bhtoys.parameters["pol_order"] = 3
+bhtoys.parameters["mass_hypo"] = 95.0
+
+# Sequence which the processors will run.
+p.sequence = [bhtoys]
+
+p.input_files=[histo_file]
+p.output_files = [toy_file]
+
+p.printProcess()

--- a/processors/config/clustersOnTracks.py
+++ b/processors/config/clustersOnTracks.py
@@ -10,6 +10,9 @@ print 'Output file: %s' % outfilename
 
 p = HpstrConf.Process()
 
+p.run_mode   = 1
+#p.max_events   = 1000
+
 # Library containing processors
 p.libraries.append("libprocessors.so")
 
@@ -29,6 +32,5 @@ p.input_files    = [infilename]
 
 p.output_files  = [outfilename]
 
-#p.max_events   = 1000
 p.printProcess()
 

--- a/processors/config/mcTuple_cfg.py
+++ b/processors/config/mcTuple_cfg.py
@@ -10,6 +10,9 @@ print('Root file: %s' % root_file)
 
 p = HpstrConf.Process()
 
+p.run_mode = 0
+#p.max_events = 1000
+
 # Library containing processors
 p.libraries.append("libprocessors.so")
 
@@ -44,7 +47,5 @@ p.sequence = [mcpart, mcthits, mcehits]
 
 p.input_files=[lcio_file]
 p.output_files = [root_file]
-
-#p.max_events = 1000
 
 p.printProcess()

--- a/processors/config/rawSvtHits_cfg.py
+++ b/processors/config/rawSvtHits_cfg.py
@@ -11,6 +11,9 @@ print('Root file: %s' % root_file)
 
 p = HpstrConf.Process()
 
+p.run_mode = 0
+#p.max_events = 1000
+
 # Library containing processors
 p.add_library("libprocessors")
 
@@ -45,7 +48,5 @@ p.sequence = [header, rawsvt]
 
 p.input_files=[lcio_file]
 p.output_files = [root_file]
-
-#p.max_events = 1000
 
 p.printProcess()

--- a/processors/config/recoTuple_cfg.py
+++ b/processors/config/recoTuple_cfg.py
@@ -10,6 +10,9 @@ print 'Root file: %s' % root_file
 
 p = HpstrConf.Process()
 
+#p.max_events = 1000
+p.run_mode = 0
+
 # Library containing processors
 p.libraries.append("libprocessors.so")
 
@@ -83,7 +86,5 @@ p.sequence = [header, track, rawsvt, svthits, ecal, vtx]
 
 p.input_files=[lcio_file]
 p.output_files = [root_file]
-
-#p.max_events = 1000
 
 p.printProcess()

--- a/processors/config/trkNtuple_cfg.py
+++ b/processors/config/trkNtuple_cfg.py
@@ -11,6 +11,9 @@ print 'Root file: %s' % root_file
 
 p = HpstrConf.Process()
 
+p.run_mode = 0
+#p.max_events = 1000
+
 # Library containing processors
 p.libraries.append("libprocessors.so")
 
@@ -50,7 +53,5 @@ p.sequence = [header, tracks]
 
 p.input_files=[lcio_file]
 p.output_files = [root_file]
-
-#p.max_events = 1000
 
 p.printProcess()

--- a/processors/include/BhToysHistoProcessor.h
+++ b/processors/include/BhToysHistoProcessor.h
@@ -2,19 +2,14 @@
 #define __BHTOYS_HISTOPROCESSOR_H__
 
 //HPSTR
-#include "HpsEvent.h"
-#include "Collections.h"
-#include "Track.h"
-#include "TrackerHit.h"
-#include "RecoHitAnaHistos.h"
-
+#include "BumpHunter.h"
+#include "FlatTupleMaker.h"
+#include "HpsFitResult.h"
 
 //ROOT
 #include "Processor.h"
-#include "TClonesArray.h"
-#include "TBranch.h"
-#include "TTree.h"
 #include "TFile.h"
+#include "TH1.h"
 
 class TTree;
 
@@ -43,9 +38,37 @@ class BhToysHistoProcessor : public Processor {
 
         TFile* inF_{nullptr};
 
+        // The bump hunter manager
+        BumpHunter* bump_hunter_{nullptr};
+
+        // The bkg model
+        BumpHunter::BkgModel bkg_model_{BumpHunter::BkgModel::EXP_POLY};
+
+        // The flat tuple manager
+        FlatTupleMaker* flat_tuple_{nullptr};
+
+        // The name of the mass spectrum to fit.
         std::string massSpectrum_{"testSpectrum_h"};
-        int polOrder_{1};
-        double massHypo_{100.0};
+
+        // The mass spectrum to fit
+        TH1* mass_spec_h{nullptr};
+
+        // The signal hypothesis to use in the fit.
+        double mass_hypo_{100.0};
+        
+        // Order of polynomial used to model the background.
+        int poly_order_{3};
+
+        // The factor that determines the size of the mass window as
+        //      window_size = (mass_resolution*win_factor)
+        int win_factor_{10};
+
+        // The seed used in generating random numbers.  The default of 0 causes
+        // the generator to use the system time.
+        int seed_{10};
+
+        // Number of toys to throw and fit
+        int nToys_{50};
 
         //Debug Level
         int debug_{0};

--- a/processors/include/BhToysHistoProcessor.h
+++ b/processors/include/BhToysHistoProcessor.h
@@ -1,0 +1,56 @@
+#ifndef __BHTOYS_HISTOPROCESSOR_H__
+#define __BHTOYS_HISTOPROCESSOR_H__
+
+//HPSTR
+#include "HpsEvent.h"
+#include "Collections.h"
+#include "Track.h"
+#include "TrackerHit.h"
+#include "RecoHitAnaHistos.h"
+
+
+//ROOT
+#include "Processor.h"
+#include "TClonesArray.h"
+#include "TBranch.h"
+#include "TTree.h"
+#include "TFile.h"
+
+class TTree;
+
+
+class BhToysHistoProcessor : public Processor {
+
+    public:
+
+        BhToysHistoProcessor(const std::string& name, Process& process);
+
+        ~BhToysHistoProcessor();
+
+        virtual void configure(const ParameterSet& parameters);
+
+        virtual void initialize(std::string inFilename, std::string outFilename);
+
+        virtual bool process();
+
+        virtual void initialize(TTree* tree) {};
+
+        virtual bool process(IEvent* event) {};
+
+        virtual void finalize();
+
+    private:
+
+        TFile* inF_{nullptr};
+
+        std::string massSpectrum_{"testSpectrum_h"};
+        int polOrder_{1};
+        double massHypo_{100.0};
+
+        //Debug Level
+        int debug_{0};
+
+};
+
+
+#endif

--- a/processors/src/BhToysHistoProcessor.cxx
+++ b/processors/src/BhToysHistoProcessor.cxx
@@ -1,0 +1,57 @@
+/**
+ * @file BhToysHistoProcessor.cxx
+ * @brief Processor used to throw toys to study BH bkg model complexity
+ * @author Cameron Bravo, SLAC National Accelerator Laboratory
+ */
+
+#include "BhToysHistoProcessor.h"
+
+BhToysHistoProcessor::BhToysHistoProcessor(const std::string& name, Process& process)
+    : Processor(name, process) { 
+    }
+
+BhToysHistoProcessor::~BhToysHistoProcessor() { 
+}
+
+void BhToysHistoProcessor::configure(const ParameterSet& parameters) {
+
+    std::cout << "Configuring BhToysHistoProcessor" << std::endl;
+    try
+    {
+        debug_          = parameters.getInteger("debug");
+        massSpectrum_   = parameters.getString("massSpectrum");
+        polOrder_       = parameters.getInteger("pol_order");
+        massHypo_       = parameters.getDouble("mass_hypo");
+    }
+    catch (std::runtime_error& error)
+    {
+        std::cout << error.what() << std::endl;
+    }
+
+
+}
+
+void BhToysHistoProcessor::initialize(std::string inFilename, std::string outFilename) {
+    inF_ = new TFile(inFilename.c_str());
+    outF_ = new TFile(outFilename.c_str(),"RECREATE");
+    //TODO: Init BumpHunter
+
+}
+
+bool BhToysHistoProcessor::process() {
+
+    std::cout << "Running on mass spectrum: " << massSpectrum_ << std::endl;
+    std::cout << "Running with pol order: " << polOrder_ << std::endl;
+    std::cout << "Running on mass hypo: " << massHypo_ << std::endl;
+
+    return true;
+}
+
+void BhToysHistoProcessor::finalize() { 
+    inF_->Close();
+    outF_->Close();
+    delete inF_;
+    delete outF_;
+}
+
+DECLARE_PROCESSOR(BhToysHistoProcessor); 

--- a/processors/src/BhToysHistoProcessor.cxx
+++ b/processors/src/BhToysHistoProcessor.cxx
@@ -43,6 +43,8 @@ void BhToysHistoProcessor::initialize(std::string inFilename, std::string outFil
 
     // Init bump hunter manager
     bump_hunter_ = new BumpHunter(bkg_model_, poly_order_, win_factor_);
+    bump_hunter_->setBounds(mass_spec_h->GetXaxis()->GetBinUpEdge(mass_spec_h->FindFirstBinAbove()),
+            mass_spec_h->GetXaxis()->GetBinLowEdge(mass_spec_h->FindLastBinAbove()));
     if(debug_ > 0) bump_hunter_->enableDebug();
 
     // Init FlatTupleMaker

--- a/processors/src/BhToysHistoProcessor.cxx
+++ b/processors/src/BhToysHistoProcessor.cxx
@@ -20,8 +20,11 @@ void BhToysHistoProcessor::configure(const ParameterSet& parameters) {
     {
         debug_          = parameters.getInteger("debug");
         massSpectrum_   = parameters.getString("massSpectrum");
-        polOrder_       = parameters.getInteger("pol_order");
-        massHypo_       = parameters.getDouble("mass_hypo");
+        mass_hypo_      = parameters.getDouble("mass_hypo");
+        win_factor_     = parameters.getInteger("win_factor");
+        poly_order_     = parameters.getInteger("poly_order");
+        seed_           = parameters.getInteger("seed");
+        nToys_          = parameters.getInteger("nToys");
     }
     catch (std::runtime_error& error)
     {
@@ -32,26 +35,160 @@ void BhToysHistoProcessor::configure(const ParameterSet& parameters) {
 }
 
 void BhToysHistoProcessor::initialize(std::string inFilename, std::string outFilename) {
+    // Init Files
     inF_ = new TFile(inFilename.c_str());
-    outF_ = new TFile(outFilename.c_str(),"RECREATE");
-    //TODO: Init BumpHunter
+
+    // Get mass spectrum from file
+    mass_spec_h = (TH1*) inF_->Get(massSpectrum_.c_str());
+
+    // Init bump hunter manager
+    bump_hunter_ = new BumpHunter(bkg_model_, poly_order_, win_factor_);
+    if(debug_ > 0) bump_hunter_->enableDebug();
+
+    // Init FlatTupleMaker
+    flat_tuple_ = new FlatTupleMaker(outFilename.c_str(), "fit_toys");
+
+    // Setup flat tuple branches
+    flat_tuple_->addVariable("bkg_total");
+    flat_tuple_->addVariable("corr_mass");
+    flat_tuple_->addVariable("mass_hypo");
+    flat_tuple_->addVariable("poly_order");
+    flat_tuple_->addVariable("win_factor");
+    flat_tuple_->addVariable("window_size");
+
+    flat_tuple_->addVariable("bkg_chi2_prob");
+    flat_tuple_->addVariable("bkg_edm");
+    flat_tuple_->addVariable("bkg_minuit_status");
+    flat_tuple_->addVariable("bkg_nll");
+
+    flat_tuple_->addVariable("edm");
+    flat_tuple_->addVariable("minuit_status");
+    flat_tuple_->addVariable("nll");
+    flat_tuple_->addVariable("p_value");
+    flat_tuple_->addVariable("q0");
+    flat_tuple_->addVariable("sig_yield");
+    flat_tuple_->addVariable("sig_yield_err");
+    flat_tuple_->addVariable("upper_limit");
+    flat_tuple_->addVariable("ul_p_value");
+    flat_tuple_->addVariable("ul_minuit_status");
+    flat_tuple_->addVector("ul_nlls");
+    flat_tuple_->addVector("ul_sig_yields");
+
+    flat_tuple_->addVariable("seed");
+    flat_tuple_->addVector("toy_bkg_chi2_prob");
+    flat_tuple_->addVector("toy_bkg_edm");
+    flat_tuple_->addVector("toy_bkg_minuit_status");
+    flat_tuple_->addVector("toy_bkg_nll");
+    flat_tuple_->addVector("toy_minuit_status");
+    flat_tuple_->addVector("toy_nll");
+    flat_tuple_->addVector("toy_p_value");
+    flat_tuple_->addVector("toy_q0");
+    flat_tuple_->addVector("toy_sig_yield");
+    flat_tuple_->addVector("toy_sig_yield_err");
+    flat_tuple_->addVector("toy_upper_limit");
 
 }
 
 bool BhToysHistoProcessor::process() {
 
     std::cout << "Running on mass spectrum: " << massSpectrum_ << std::endl;
-    std::cout << "Running with pol order: " << polOrder_ << std::endl;
-    std::cout << "Running on mass hypo: " << massHypo_ << std::endl;
+    std::cout << "Running with polynomial order: " << poly_order_ << std::endl;
+    std::cout << "Running with window factor: " << win_factor_ << std::endl;
+    std::cout << "Running on mass hypo: " << mass_hypo_ << std::endl;
+
+    // Search for a resonance at the given mass hypothesis
+    HpsFitResult* result = bump_hunter_->performSearch(mass_spec_h, mass_hypo_, false, true);
+    mass_spec_h->Write();
+
+    // Get the result of the background fit
+    TFitResultPtr bkg_result = result->getBkgFitResult();
+
+    std::cout << "Filling Fit Results " << std::endl;
+    // Get the result of the signal+background fit
+    TFitResultPtr sig_result = result->getCompFitResult();
+
+    // Set the Fit Parameters in the flat tuple
+    flat_tuple_->setVariableValue("bkg_total",              result->getIntegral());
+    flat_tuple_->setVariableValue("corr_mass",              result->getCorrectedMass());
+    flat_tuple_->setVariableValue("mass_hypo",              result->getMass());
+    flat_tuple_->setVariableValue("poly_order",             poly_order_);
+    flat_tuple_->setVariableValue("win_factor",             win_factor_);
+    flat_tuple_->setVariableValue("window_size",            result->getWindowSize());
+
+    // Set the Fit Results in the flat tuple
+    flat_tuple_->setVariableValue("bkg_chi_prob",           bkg_result->Prob());
+    flat_tuple_->setVariableValue("bkg_edm",                bkg_result->Edm());
+    flat_tuple_->setVariableValue("bkg_minuit_status",      bkg_result->Status());
+    flat_tuple_->setVariableValue("bkg_nll",                bkg_result->MinFcnValue());
+
+    flat_tuple_->setVariableValue("edm",                    sig_result->Edm());
+    flat_tuple_->setVariableValue("minuit_status",          sig_result->Status());
+    flat_tuple_->setVariableValue("nll",                    sig_result->MinFcnValue());
+    flat_tuple_->setVariableValue("p_value",                result->getPValue());
+    flat_tuple_->setVariableValue("q0",                     result->getQ0());
+    flat_tuple_->setVariableValue("sig_yield",              result->getSignalYield());
+    flat_tuple_->setVariableValue("sig_yield_err",          result->getSignalYieldErr());
+    flat_tuple_->setVariableValue("upper_limit",            result->getUpperLimit());
+    flat_tuple_->setVariableValue("upper_limit_p_value",    result->getUpperLimitPValue());
+
+    for (auto& likelihood : result->getLikelihoods()) {
+        flat_tuple_->addToVector("nlls", likelihood);
+    }
+
+    for (auto& yield : result->getSignalYields()) {
+        flat_tuple_->addToVector("sig_yields", yield);
+    }
+
+    std::vector<HpsFitResult*> toy_results;
+    flat_tuple_->setVariableValue("seed", seed_);
+    if (nToys_ > 0) {
+
+        std::cout << "Generating " << nToys_ << " Toys" <<std::endl;
+        std::vector<TH1*> toys_hist = bump_hunter_->generateToys(mass_spec_h, nToys_, seed_);
+
+        int toyFitN = 0;
+        for (TH1* hist : toys_hist) {
+            std::cout << "Fitting Toy " << toyFitN << std::endl;
+            toy_results.push_back(bump_hunter_->performSearch(hist, mass_hypo_, false, true));
+            toyFitN++;
+        }
+    }
+
+    for (auto& toy_result : toy_results) {
+
+        // Get the result of the background fit
+        TFitResultPtr toy_bkg_result = toy_result->getBkgFitResult();
+
+        flat_tuple_->addToVector("toy_bkg_chi2_prob",     toy_bkg_result->Prob());
+        flat_tuple_->addToVector("toy_bkg_edm",           toy_bkg_result->Edm());
+        flat_tuple_->addToVector("toy_bkg_minuit_status", toy_bkg_result->Status());
+        flat_tuple_->addToVector("toy_bkg_nll",           toy_bkg_result->MinFcnValue());
+
+        // Get the result of the signal+background fit
+        TFitResultPtr toy_sig_result = toy_result->getCompFitResult();
+
+        // Retrieve all of the result of interest. 
+        flat_tuple_->addToVector("toy_minuit_status", toy_sig_result->Status());
+        flat_tuple_->addToVector("toy_nll",           toy_sig_result->MinFcnValue());
+        flat_tuple_->addToVector("toy_p_value",       toy_result->getPValue());
+        flat_tuple_->addToVector("toy_q0",            toy_result->getQ0());
+        flat_tuple_->addToVector("toy_sig_yield",     toy_result->getSignalYield());
+        flat_tuple_->addToVector("toy_sig_yield_err", toy_result->getSignalYieldErr());
+        flat_tuple_->addToVector("toy_upper_limit",   toy_result->getUpperLimit());
+    }
+
+    // Fill and write the flat tuple
+    flat_tuple_->fill();
+    flat_tuple_->close();
 
     return true;
 }
 
 void BhToysHistoProcessor::finalize() { 
     inF_->Close();
-    outF_->Close();
     delete inF_;
-    delete outF_;
+    //delete flat_tuple_;
+    delete bump_hunter_;
 }
 
 DECLARE_PROCESSOR(BhToysHistoProcessor); 


### PR DESCRIPTION
Changed Process to include a run mode which defines how hpstr will choose the which process method to call. This now includes 3 different modes:
1. LCIO -> ROOT (Processors)
2. ROOT -> Histo (AnaProcessors)
3. Histo Analysis (HistoProcessors)

Ported bump-hunter into the first processor for mode 3, BhToysHistoProcessor.