### PR TITLE
Add the initializations to the Configure step as default

### DIFF
--- a/processing/src/hpstr.cxx
+++ b/processing/src/hpstr.cxx
@@ -90,8 +90,8 @@ int main(int argc, char **argv) {
         std::cout << "---- [ hpstr ]: Event processing complete  --------" << std::endl;
 
     } catch (exception& e) { 
-        //std::cerr << "Error! [" << e.name() << "] : " << e.message() << std::endl;
-        //std::cerr << "  at " << e.module() << ":" << e.line() << " in " << e.function() << std::endl;
+        std::cerr << "Error! [" << e.what() << "] \n";
+        std::cerr << "Program aborted. " << std::endl;
 
     } 
 

--- a/processors/include/ECalDataProcessor.h
+++ b/processors/include/ECalDataProcessor.h
@@ -92,7 +92,7 @@ class ECalDataProcessor : public Processor {
 
         /** TClonesArray collection containing all ECal hits. */ 
         std::vector<CalHit*> cal_hits_; 
-        std::string hitCollLcio_{"TimeCorrEcalHits"};
+        std::string hitCollLcio_{"EcalCalHits"};
         std::string hitCollRoot_{"RecoEcalHits"};
 
         /** TClonesArray collection containing all ECal clusters. */

--- a/processors/src/ECalDataProcessor.cxx
+++ b/processors/src/ECalDataProcessor.cxx
@@ -19,11 +19,11 @@ void ECalDataProcessor::configure(const ParameterSet& parameters) {
     std::cout << "Configuring ECalDataProcessor" << std::endl;
     try
     {
-        debug_         = parameters.getInteger("debug");
-        hitCollLcio_   = parameters.getString("hitCollLcio");
-        hitCollRoot_   = parameters.getString("hitCollRoot");
-        clusCollLcio_  = parameters.getString("clusCollLcio");
-        clusCollRoot_  = parameters.getString("clusCollRoot");
+        debug_         = parameters.getInteger("debug", debug_);
+        hitCollLcio_   = parameters.getString("hitCollLcio", hitCollLcio_);
+        hitCollRoot_   = parameters.getString("hitCollRoot", hitCollRoot_);
+        clusCollLcio_  = parameters.getString("clusCollLcio", clusCollLcio_);
+        clusCollRoot_  = parameters.getString("clusCollRoot", clusCollRoot_);
     }
     catch (std::runtime_error& error)
     {

--- a/processors/src/EventProcessor.cxx
+++ b/processors/src/EventProcessor.cxx
@@ -20,14 +20,14 @@ void EventProcessor::configure(const ParameterSet& parameters) {
     std::cout << "Configuring EventProcessor" << std::endl;
     try
     {
-        debug_         = parameters.getInteger("debug");
-        headCollRoot_  = parameters.getString("headCollRoot");
-        trigCollLcio_    = parameters.getString("trigCollLcio");
-        rfCollLcio_    = parameters.getString("rfCollLcio");
-        vtpCollLcio_   = parameters.getString("vtpCollLcio");
-        vtpCollRoot_   = parameters.getString("vtpCollRoot");
-        tsCollLcio_  = parameters.getString("tsCollLcio");
-        tsCollRoot_  = parameters.getString("tsCollRoot");
+        debug_         = parameters.getInteger("debug", debug_);
+        headCollRoot_  = parameters.getString("headCollRoot", headCollRoot_);
+        trigCollLcio_    = parameters.getString("trigCollLcio", trigCollLcio_);
+        rfCollLcio_    = parameters.getString("rfCollLcio", rfCollLcio_ );
+        vtpCollLcio_   = parameters.getString("vtpCollLcio", vtpCollLcio_);
+        vtpCollRoot_   = parameters.getString("vtpCollRoot", vtpCollRoot_ );
+        tsCollLcio_  = parameters.getString("tsCollLcio", tsCollLcio_);
+        tsCollRoot_  = parameters.getString("tsCollRoot", tsCollRoot_);
     }
     catch (std::runtime_error& error)
     {

--- a/processors/src/MCEcalHitProcessor.cxx
+++ b/processors/src/MCEcalHitProcessor.cxx
@@ -17,9 +17,9 @@ void MCEcalHitProcessor::configure(const ParameterSet& parameters) {
     std::cout << "Configuring MCEcalHitProcessor" << std::endl;
     try
     {
-        debug_         = parameters.getInteger("debug");
-        hitCollLcio_   = parameters.getString("hitCollLcio");
-        hitCollRoot_   = parameters.getString("hitCollRoot");
+        debug_         = parameters.getInteger("debug", debug_);
+        hitCollLcio_   = parameters.getString("hitCollLcio", hitCollLcio_);
+        hitCollRoot_   = parameters.getString("hitCollRoot", hitCollRoot_);
     }
     catch (std::runtime_error& error)
     {

--- a/processors/src/MCParticleProcessor.cxx
+++ b/processors/src/MCParticleProcessor.cxx
@@ -19,9 +19,9 @@ void MCParticleProcessor::configure(const ParameterSet& parameters) {
     std::cout << "Configuring MCParticleProcessor" << std::endl;
     try
     {
-        debug_          = parameters.getInteger("debug");
-        mcPartCollLcio_    = parameters.getString("mcPartCollLcio");
-        mcPartCollRoot_    = parameters.getString("mcPartCollRoot");
+        debug_          = parameters.getInteger("debug", debug_ );
+        mcPartCollLcio_    = parameters.getString("mcPartCollLcio", mcPartCollLcio_);
+        mcPartCollRoot_    = parameters.getString("mcPartCollRoot", mcPartCollRoot_);
     }
     catch (std::runtime_error& error)
     {

--- a/processors/src/MCTrackerHitProcessor.cxx
+++ b/processors/src/MCTrackerHitProcessor.cxx
@@ -17,9 +17,9 @@ void MCTrackerHitProcessor::configure(const ParameterSet& parameters) {
     std::cout << "Configuring MCTrackerHitProcessor" << std::endl;
     try
     {
-        debug_         = parameters.getInteger("debug");
-        hitCollLcio_   = parameters.getString("hitCollLcio");
-        hitCollRoot_   = parameters.getString("hitCollRoot");
+        debug_         = parameters.getInteger("debug", debug_ );
+        hitCollLcio_   = parameters.getString("hitCollLcio", hitCollLcio_);
+        hitCollRoot_   = parameters.getString("hitCollRoot", hitCollRoot_);
     }
     catch (std::runtime_error& error)
     {

--- a/processors/src/SvtRawDataProcessor.cxx
+++ b/processors/src/SvtRawDataProcessor.cxx
@@ -17,10 +17,10 @@ void SvtRawDataProcessor::configure(const ParameterSet& parameters) {
     std::cout << "Configuring SvtRawDataProcessor" << std::endl;
     try
     {
-        debug_         = parameters.getInteger("debug");
-        hitCollLcio_   = parameters.getString("hitCollLcio");
-        hitfitCollLcio_   = parameters.getString("hitfitCollLcio");
-        hitCollRoot_   = parameters.getString("hitCollRoot");
+        debug_         = parameters.getInteger("debug", debug_);
+        hitCollLcio_   = parameters.getString("hitCollLcio", hitCollLcio_);
+        hitfitCollLcio_   = parameters.getString("hitfitCollLcio", hitfitCollLcio_);
+        hitCollRoot_   = parameters.getString("hitCollRoot", hitCollRoot_);
     }
     catch (std::runtime_error& error)
     {

--- a/processors/src/Tracker3DHitProcessor.cxx
+++ b/processors/src/Tracker3DHitProcessor.cxx
@@ -13,10 +13,10 @@ void Tracker3DHitProcessor::configure(const ParameterSet& parameters) {
     std::cout << "Configuring Tracker3DHitProcessor" << std::endl;
     try
     {
-        debug_          = parameters.getInteger("debug");
-        hitCollLcio_    = parameters.getString("hitCollLcio");
-        hitCollRoot_    = parameters.getString("hitCollRoot");
-        mcPartRelLcio_ = parameters.getString("mcPartRelLcio");
+        debug_          = parameters.getInteger("debug", debug_);
+        hitCollLcio_    = parameters.getString("hitCollLcio", hitCollLcio_);
+        hitCollRoot_    = parameters.getString("hitCollRoot", hitCollRoot_);
+        mcPartRelLcio_ = parameters.getString("mcPartRelLcio", mcPartRelLcio_);
     }
     catch (std::runtime_error& error)
     {

--- a/processors/src/TrackingProcessor.cxx
+++ b/processors/src/TrackingProcessor.cxx
@@ -14,14 +14,14 @@ void TrackingProcessor::configure(const ParameterSet& parameters) {
     std::cout << "Configuring TrackingProcessor" << std::endl;
     try
     {
-        debug_          = parameters.getInteger("debug");
-        trkCollLcio_    = parameters.getString("trkCollLcio");
-        trkCollRoot_    = parameters.getString("trkCollRoot");
-        kinkRelCollLcio_    = parameters.getString("kinkRelCollLcio");
-        trkRelCollLcio_    = parameters.getString("trkRelCollLcio");
-        trkhitCollRoot_    = parameters.getString("trkhitCollRoot");
-        hitFitsCollLcio_    = parameters.getString("hitFitsCollLcio");
-        rawhitCollRoot_    = parameters.getString("rawhitCollRoot");
+        debug_           = parameters.getInteger("debug", debug_);
+        trkCollLcio_     = parameters.getString("trkCollLcio", trkCollLcio_);
+        trkCollRoot_     = parameters.getString("trkCollRoot", trkCollRoot_);
+        kinkRelCollLcio_ = parameters.getString("kinkRelCollLcio", kinkRelCollLcio_);
+        trkRelCollLcio_  = parameters.getString("trkRelCollLcio", trkRelCollLcio_);
+        trkhitCollRoot_  = parameters.getString("trkhitCollRoot", trkhitCollRoot_);
+        hitFitsCollLcio_ = parameters.getString("hitFitsCollLcio", hitFitsCollLcio_);
+        rawhitCollRoot_  = parameters.getString("rawhitCollRoot", rawhitCollRoot_);
     }
     catch (std::runtime_error& error)
     {

--- a/processors/src/VertexProcessor.cxx
+++ b/processors/src/VertexProcessor.cxx
@@ -18,12 +18,12 @@ void VertexProcessor::configure(const ParameterSet& parameters) {
     std::cout << "Configuring VertexProcessor" << std::endl;
     try
     {
-        debug_             = parameters.getInteger("debug");
-        vtxCollLcio_       = parameters.getString("vtxCollLcio");
-        vtxCollRoot_       = parameters.getString("vtxCollRoot");
-        partCollRoot_      = parameters.getString("partCollRoot");
-        kinkRelCollLcio_   = parameters.getString("kinkRelCollLcio");
-        trkRelCollLcio_    = parameters.getString("trkRelCollLcio");
+        debug_             = parameters.getInteger("debug", debug_);
+        vtxCollLcio_       = parameters.getString("vtxCollLcio", vtxCollLcio_);
+        vtxCollRoot_       = parameters.getString("vtxCollRoot", vtxCollRoot_);
+        partCollRoot_      = parameters.getString("partCollRoot", partCollRoot_);
+        kinkRelCollLcio_   = parameters.getString("kinkRelCollLcio", kinkRelCollLcio_);
+        trkRelCollLcio_    = parameters.getString("trkRelCollLcio", trkRelCollLcio_);
         
     }
     catch (std::runtime_error& error)


### PR DESCRIPTION
Simple change to the configure step to use the initialization of the variable as the default for the parameters. That way the code runs okay if a parameter is not set.

Also, in case something goes wrong, print a message when the exception is caught. That was all commented out.