### PR TITLE
Updates hpstr analysis for Kalman validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,16 @@
 # Byte code
 *.pyc
 
+# Emacs temporary files
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
 # Eclipse files
 .cproject
 .project

--- a/analysis/plotconfigs/tracking/basicTracking.json
+++ b/analysis/plotconfigs/tracking/basicTracking.json
@@ -6,6 +6,13 @@
         "xtitle" : "N_{tracks}",
         "ytitle" : "Events"
     },
+    "nHits_2d_h" : {
+        "bins"  : 15,
+        "minX"  : 0,
+        "maxX"  : 15,
+        "xtitle" : "N_{2Dhits}",
+        "ytitle" : "Tracks"
+    },
     "strategy_h" : {
         "bins" : 6,
         "minX" : -0.5,
@@ -55,6 +62,20 @@
         "minX" : -0.002,
         "maxX" : 0.002,
         "xtitle" : "#omega",
+        "ytitle" : "Tracks"
+    },
+    "invpT_h" : {
+        "bins" : 100,
+        "minX" : -2.5,
+        "maxX" : 2.5,
+        "xtitle" : "q/pT [GeV^{-1}]",
+        "ytitle" : "Tracks"
+    },
+    "pT_h" : {
+        "bins" : 100,
+        "minX" : -3,
+        "maxX" : 3,
+        "xtitle" : "q*pT [GeV^{-1}]",
         "ytitle" : "Tracks"
     },
     "TanLambda_h" : {

--- a/analysis/selections/customCuts.json
+++ b/analysis/selections/customCuts.json
@@ -18,15 +18,5 @@
         "cut"   : 20,
         "id"    : 3,
         "info"  : "#chi^{2}_{unc}<10"
-    },
-    "eleMom_gt" : {
-        "cut" : 0.4,
-        "id"  : 4,
-        "info" : "p_e^{-}>0.4 [GeV]"
-    },
-    "posMom_gt" : {
-        "cut" : 0.4,
-        "id"  : 5,
-        "info" : "p_e^{+}>0.4 [GeV]"
     }
 }

--- a/processors/config/anaKalTruth_cfg.py
+++ b/processors/config/anaKalTruth_cfg.py
@@ -1,0 +1,48 @@
+import HpstrConf
+import sys
+import os
+import baseConfig
+
+(options,args) = baseConfig.parser.parse_args()
+
+
+# Use the input file to set the output file name
+infile = options.inFilename
+outfile = options.outFilename
+
+print 'Input file: %s' % infile
+print 'Output file: %s' % outfile
+
+p = HpstrConf.Process()
+
+p.run_mode = 1
+#p.max_events = 1000
+
+# Library containing processors
+p.libraries.append("libprocessors.so")
+
+###############################
+#          Processors         #
+###############################
+trkana    = HpstrConf.Processor('trkana','TrackingAnaProcessor')
+trkgblana = HpstrConf.Processor('trkgblana','TrackingAnaProcessor')
+
+trkana.parameters["debug"]  = 0;
+trkana.parameters["trkCollName"] = "KalmanFullTracks"
+trkana.parameters["histCfg"] = os.environ['HPSTR_BASE'] + '/analysis/plotconfigs/tracking/basicTracking.json'
+trkana.parameters["doTruth"] = 1
+trkana.parameters["truthHistCfg"] = os.environ['HPSTR_BASE'] + '/analysis/plotconfigs/tracking/truthTrackComparison.json'
+
+
+trkgblana.parameters["debug"]        = 0;
+trkgblana.parameters["trkCollName"]  = "GBLRefittedTracks"
+trkgblana.parameters["histCfg"]      = os.environ['HPSTR_BASE'] + '/analysis/plotconfigs/tracking/basicTracking.json'
+trkgblana.parameters["doTruth"]      = 1
+trkgblana.parameters["truthHistCfg"] = os.environ['HPSTR_BASE'] + '/analysis/plotconfigs/tracking/truthTrackComparison.json'
+
+p.sequence = [trkana,trkgblana]
+
+p.input_files = [infile]
+p.output_files = [outfile]
+
+p.printProcess()

--- a/processors/config/anaKalVtxTuple_cfg.py
+++ b/processors/config/anaKalVtxTuple_cfg.py
@@ -1,0 +1,88 @@
+import HpstrConf
+import sys
+import os
+import baseConfig
+
+(options,args) = baseConfig.parser.parse_args()
+
+
+# Use the input file to set the output file name
+infile = options.inFilename
+outfile = options.outFilename
+
+print 'Input file: %s' % infile
+print 'Output file: %s' % outfile
+
+p = HpstrConf.Process()
+
+p.run_mode = 1
+#p.max_events = 1000
+
+# Library containing processors
+p.libraries.append("libprocessors.so")
+
+###############################
+#          Processors         #
+###############################
+
+recoana_kf = HpstrConf.Processor('vtxana_kf', 'VertexAnaProcessor')
+recoana_gbl = HpstrConf.Processor('vtxana_gbl', 'VertexAnaProcessor')
+
+###############################
+#   Processor Configuration   #
+###############################
+#RecoHitAna
+recoana_kf.parameters["debug"] = 1
+recoana_kf.parameters["anaName"] = "vtxana_kf"
+recoana_kf.parameters["trkColl"] = ""
+recoana_kf.parameters["vtxColl"] = "UnconstrainedV0Vertices_KF"
+recoana_kf.parameters["vtxSelectionjson"] = os.environ['HPSTR_BASE']+'/analysis/selections/customCuts.json'
+#recoana.parameters["vtxSelectionjson"] = os.environ['HPSTR_BASE']+'/analysis/selections/vtxSelection_noLyReq.json'
+recoana_kf.parameters["histoCfg"] = os.environ['HPSTR_BASE']+"/analysis/plotconfigs/tracking/vtxAnalysis_2019.json"
+recoana_kf.parameters["beamE"] = 2.3
+recoana_kf.parameters["isData"] = options.isData
+CalTimeOffset=-999.
+
+if (options.isData==1):
+    CalTimeOffset=56.
+    print "Running on data file: Setting CalTimeOffset %d"  % CalTimeOffset
+    
+elif (options.isData==0):
+    CalTimeOffset=43.
+    print "Running on MC file: Setting CalTimeOffset %d"  % CalTimeOffset
+else:
+    print "Specify which type of ntuple you are running on: -t 1 [for Data] / -t 0 [for MC]"
+
+
+recoana_kf.parameters["CalTimeOffset"]=CalTimeOffset
+#Region definitions
+
+RegionPath=os.environ['HPSTR_BASE']+"/analysis/selections/"
+recoana_kf.parameters["regionDefinitions"] = [RegionPath+'Tight.json']
+
+#RecoHitAna
+recoana_gbl.parameters = recoana_kf.parameters.copy()
+recoana_gbl.parameters["anaName"] = "vtxana_gbl"
+recoana_gbl.parameters["vtxColl"] = "UnconstrainedV0Vertices"
+recoana_gbl.parameters["trkColl"] = "GBLTracks"
+
+#    
+#    RegionPath+'ESumCR.json',
+#    RegionPath+'TightNoSharedL0.json',
+#    RegionPath+'TightNoShared.json',
+
+# Sequence which the processors will run.
+#p.sequence = [recoana_kf,recoana_gbl]
+p.sequence = [recoana_kf]
+#p.sequence = [recoana_gbl]
+
+
+if (options.nevents > 0):
+    p.max_events = options.nevents
+
+p.input_files=[infile]
+p.output_files = [outfile]
+
+p.printProcess()
+
+

--- a/processors/config/kalTuple_cfg.py
+++ b/processors/config/kalTuple_cfg.py
@@ -1,0 +1,135 @@
+import HpstrConf
+import sys
+
+import baseConfig
+
+parser = baseConfig.parser
+(options,args) = parser.parse_args()
+
+# Use the input file to set the output file name
+lcio_file = options.inFilename
+root_file = options.outFilename
+
+print 'LCIO file: %s' % lcio_file
+print 'Root file: %s' % root_file
+
+p = HpstrConf.Process()
+
+#p.max_events = 1000
+p.run_mode = 0
+
+# Library containing processors
+p.libraries.append("libprocessors.so")
+
+###############################
+#          Processors         #
+###############################
+header  = HpstrConf.Processor('header', 'EventProcessor')
+track   = HpstrConf.Processor('track', 'TrackingProcessor')
+trackgbl = HpstrConf.Processor('trackgbl', 'TrackingProcessor')
+trackrefitgbl = HpstrConf.Processor('trackrefitgbl', 'TrackingProcessor')
+svthits = HpstrConf.Processor('svthits', 'Tracker3DHitProcessor')
+rawsvt  = HpstrConf.Processor('rawsvt', 'SvtRawDataProcessor')
+ecal    = HpstrConf.Processor('ecal', 'ECalDataProcessor')
+vtx     = HpstrConf.Processor('vtx', 'VertexProcessor')
+vtxgbl   = HpstrConf.Processor('vtxgbl', 'VertexProcessor')
+mcpart  = HpstrConf.Processor('mcpart', 'MCParticleProcessor')
+
+###############################
+#   Processor Configuration   #
+###############################
+#Event
+header.parameters["debug"] = 0
+header.parameters["headCollRoot"] = "EventHeader"
+header.parameters["trigCollLcio"] = "TriggerBank"
+header.parameters["rfCollLcio"]   = "RFHits"
+header.parameters["vtpCollLcio"]  = "VTPBank"
+header.parameters["vtpCollRoot"]  = "VTPBank"
+header.parameters["tsCollLcio"]   = "TSBank"
+header.parameters["tsCollRoot"]   = "TSBank"
+
+#SvtRawData
+rawsvt.parameters["debug"] = 0
+rawsvt.parameters["hitCollLcio"]    = 'SVTRawTrackerHits'
+rawsvt.parameters["hitfitCollLcio"] = 'SVTFittedRawTrackerHits'
+rawsvt.parameters["hitCollRoot"]    = 'SVTRawTrackerHits'
+
+#Tracker3DHits
+svthits.parameters["debug"] = 0
+svthits.parameters["hitCollLcio"]    = 'RotatedHelicalTrackHits'
+svthits.parameters["hitCollRoot"]    = 'RotatedHelicalTrackHits'
+
+
+#Tracking
+track.parameters["debug"] = 0 
+track.parameters["trkCollLcio"] = 'KalmanFullTracks'
+track.parameters["trkCollRoot"] = 'KalmanFullTracks'
+track.parameters["kinkRelCollLcio"] = ''
+track.parameters["trkRelCollLcio"] = ''#'KFTrackDataRelations'
+track.parameters["trkhitCollRoot"] = ''
+track.parameters["hitFitsCollLcio"] = ''
+track.parameters["rawhitCollRoot"] = ''
+track.parameters["truthTrackCollLcio"] = 'KalmanFullTracksToTruthTrackRelations'
+track.parameters["truthTrackCollRoot"] = 'Truth_KFTracks'
+track.parameters["bfield"] = 0.5234
+
+trackgbl.parameters["debug"] = 0 
+trackgbl.parameters["trkCollLcio"] = 'GBLTracks'
+trackgbl.parameters["trkCollRoot"] = 'GBLTracks'
+trackgbl.parameters["kinkRelCollLcio"] = ''#'GBLKinkDataRelations'
+trackgbl.parameters["trkRelCollLcio"] = ''#'TrackDataRelations'
+trackgbl.parameters["trkhitCollRoot"] = 'RotatedHelicalOnTrackHits'
+trackgbl.parameters["hitFitsCollLcio"] = 'SVTFittedRawTrackerHits'
+trackgbl.parameters["rawhitCollRoot"] = 'SVTRawHitsOnTrack'
+trackgbl.parameters["truthTrackCollLcio"] = ''#'GBLTracksToTruthTrackRelations'
+trackgbl.parameters["truthTrackCollRoot"] = 'Truth_GBLTracks'
+trackgbl.parameters["bfield"] = 0.5234
+
+trackrefitgbl.parameters["debug"] = 0 
+trackrefitgbl.parameters["trkCollLcio"] = 'GBLRefittedTracks'
+trackrefitgbl.parameters["trkCollRoot"] = 'GBLRefittedTracks'
+trackrefitgbl.parameters["kinkRelCollLcio"] = ''#'GBLKinkDataRelations'
+trackrefitgbl.parameters["trkRelCollLcio"] = ''#'TrackDataRelations'
+trackrefitgbl.parameters["trkhitCollRoot"] = 'RotatedHelicalOnTrackHits'
+trackrefitgbl.parameters["hitFitsCollLcio"] = 'SVTFittedRawTrackerHits'
+trackrefitgbl.parameters["rawhitCollRoot"] = 'SVTRawHitsOnTrack'
+trackrefitgbl.parameters["truthTrackCollLcio"] = 'GBLRefittedTracksToTruthTrackRelations'
+trackrefitgbl.parameters["truthTrackCollRoot"] = 'Truth_GBLRefittedTracks'
+trackrefitgbl.parameters["bfield"] = 0.5234
+
+#ECalData
+ecal.parameters["debug"] = 0 
+ecal.parameters["hitCollLcio"] = 'EcalCalHits'
+ecal.parameters["hitCollRoot"] = 'RecoEcalHits'
+ecal.parameters["clusCollLcio"] = "EcalClustersCorr"
+ecal.parameters["clusCollRoot"] = "RecoEcalClusters"
+
+#Vertex
+vtx.parameters["debug"] = 0
+vtx.parameters["vtxCollLcio"]    = 'UnconstrainedV0Vertices_KF'
+vtx.parameters["vtxCollRoot"]    = 'UnconstrainedV0Vertices_KF'
+vtx.parameters["partCollRoot"]   = 'ParticlesOnVertices_KF'
+vtx.parameters["kinkRelCollLcio"] = ''
+vtx.parameters["trkRelCollLcio"] = ''#'KFTrackDataRelations'
+
+#Constrained Vertex
+vtxgbl.parameters["debug"] = 0
+vtxgbl.parameters["vtxCollLcio"]     = 'UnconstrainedV0Vertices'
+vtxgbl.parameters["vtxCollRoot"]     = 'UnconstrainedV0Vertices'
+vtxgbl.parameters["partCollRoot"]    = 'ParticlesOnVertices'
+vtxgbl.parameters["kinkRelCollLcio"] = 'GBLKinkDataRelations'
+vtxgbl.parameters["trkRelCollLcio"]  = 'TrackDataRelations'
+
+
+#MCParticle
+mcpart.parameters["debug"] = 0 
+mcpart.parameters["mcPartCollLcio"] = 'MCParticle'
+mcpart.parameters["mcPartCollRoot"] = 'MCParticle'
+
+# Sequence which the processors will run.
+p.sequence = [header, vtx, vtxgbl, track, trackgbl,trackrefitgbl]
+
+p.input_files=[lcio_file]
+p.output_files = [root_file]
+
+p.printProcess()

--- a/processors/include/TrackingAnaProcessor.h
+++ b/processors/include/TrackingAnaProcessor.h
@@ -78,8 +78,10 @@ class TrackingAnaProcessor : public Processor {
 
         // Containers to hold histogrammer info
         std::string histCfgFilename_;
-        TrackHistos* trkHistos_;
-
+        std::string truthHistCfgFilename_;
+        TrackHistos* trkHistos_{nullptr};
+        TrackHistos* truthHistos_{nullptr};
+        bool doTruth_{false};
         int debug_{0};
 
 

--- a/processors/include/TrackingProcessor.h
+++ b/processors/include/TrackingProcessor.h
@@ -99,10 +99,17 @@ class TrackingProcessor : public Processor {
         std::vector<RawSvtHit*> rawhits_{};
         std::string hitFitsCollLcio_{"SVTFittedRawTrackerHits"};
         std::string rawhitCollRoot_{"SVTRawHitsOnTrack"};
+        
+        /** Container to hold truth tracks */
+        std::vector<Track*> truthTracks_{};
+        std::string truthTracksCollRoot_{""};
+        std::string truthTracksCollLcio_{""};
 
         //Debug Level
         int debug_{false};
-
+        
+        //Bfield
+        double bfield_{0.52};
 
 
 

--- a/processors/src/TrackingAnaProcessor.cxx
+++ b/processors/src/TrackingAnaProcessor.cxx
@@ -14,9 +14,11 @@ void TrackingAnaProcessor::configure(const ParameterSet& parameters) {
     std::cout << "Configuring TrackingAnaProcessor" << std::endl;
     try
     {
-        debug_          = parameters.getInteger("debug");
-        trkCollName_    = parameters.getString("trkCollName");
+        debug_           = parameters.getInteger("debug");
+        trkCollName_     = parameters.getString("trkCollName");
         histCfgFilename_ = parameters.getString("histCfg");
+        doTruth_         = (bool) parameters.getInteger("doTruth");
+        truthHistCfgFilename_ = parameters.getString("truthHistCfg");
     }
     catch (std::runtime_error& error)
     {
@@ -32,9 +34,20 @@ void TrackingAnaProcessor::initialize(TTree* tree) {
     trkHistos_->loadHistoConfig(histCfgFilename_);
     trkHistos_->doTrackComparisonPlots(false);
     trkHistos_->DefineHistos();
-
     // Init tree
     tree->SetBranchAddress(trkCollName_.c_str(), &tracks_, &btracks_);
+    
+    
+    if (doTruth_) {
+        truthHistos_ = new TrackHistos(trkCollName_+"_truthComparison");
+        truthHistos_->loadHistoConfig(histCfgFilename_);
+        truthHistos_->DefineHistos();
+        truthHistos_->loadHistoConfig(truthHistCfgFilename_);
+        truthHistos_->DefineHistos();
+        truthHistos_->doTrackComparisonPlots(false);
+        
+        //tree->SetBranchAddress(truthCollName_.c_str(),&truth_tracks_,&btruth_tracks_);
+    }
 
 }
 
@@ -46,6 +59,21 @@ bool TrackingAnaProcessor::process(IEvent* ievent) {
         // Get a track
         Track* track = tracks_->at(itrack);
 
+        //Select Kalman Tracks with at least 10 hits
+        if (track->isKalmanTrack()) {
+            if (track->getTrackerHitCount() < 10 )
+                continue;
+        }
+
+        Track* truth_track = nullptr;
+
+        //Get the truth track
+        if (doTruth_) { 
+            truth_track = (Track*) track->getTruthLink().GetObject();
+            if (!truth_track)
+                std::cout<<"Warnings::TrackingAnaProcessor::Requested Truth track but couldn't find it in the ntuple"<<std::endl;
+        }
+        
         if(debug_ > 0)
         {
             std::cout<<"========================================="<<std::endl;
@@ -53,9 +81,16 @@ bool TrackingAnaProcessor::process(IEvent* ievent) {
             std::cout<<"Track params:           "<<std::endl;
             track->Print();
         }
-
+        
         trkHistos_->Fill1DHistograms(track);
         trkHistos_->Fill2DTrack(track);
+        
+        if (truthHistos_) {
+            truthHistos_->Fill1DHistograms(truth_track);
+            truthHistos_->Fill2DTrack(track);
+            truthHistos_->Fill1DTrackTruth(track, truth_track);
+        }
+        
     }//Loop on tracks
 
     trkHistos_->Fill1DHisto("n_tracks_h",tracks_->size());
@@ -65,11 +100,16 @@ bool TrackingAnaProcessor::process(IEvent* ievent) {
 
 void TrackingAnaProcessor::finalize() { 
 
-    trkHistos_->saveHistos(outF_);
+    trkHistos_->saveHistos(outF_,trkCollName_);
     delete trkHistos_;
     trkHistos_ = nullptr;
-    //trkHistos_->Clear();
 
+    if (truthHistos_) {
+        truthHistos_->saveHistos(outF_,trkCollName_+"_truth");
+        delete truthHistos_;
+        truthHistos_ = nullptr;
+    }
+    //trkHistos_->Clear();
 }
 
 DECLARE_PROCESSOR(TrackingAnaProcessor); 

--- a/processors/src/utilities.cxx
+++ b/processors/src/utilities.cxx
@@ -171,7 +171,10 @@ Track* utils::buildTrack(EVENT::Track* lc_track,
 
     // Set the track ndf 
     track->setNdf(lc_track->getNdf());
-
+    
+    // Set the track covariance matrix
+    track->setCov(static_cast<std::vector<float> > (lc_track->getCovMatrix()));
+    
     // Set the position of the extrapolated track at the ECal face.  The
     // extrapolation uses the full 3D field map.
     const EVENT::TrackState* track_state 

--- a/scripts/run_shPool.py
+++ b/scripts/run_shPool.py
@@ -106,7 +106,7 @@ if __name__ == '__main__':
     print "Testing %i jobs in parallel mode (using Pool(%i))"%(len(shList),options.poolSize)
     print list(
               itertools.izip(shList,
-                             [options.outDir     for x in range(len(shList))],
+                             [options.logDir     for x in range(len(shList))],
                              range(len(shList))
                             )
               )


### PR DESCRIPTION
Summary of changes:
- Updated .gitignore to include ignoring emacs temporary files. 
- Added a "basicTracking.json" with some extra validation plots for tracking performance
- Added "customCuts.json" for really basic cuts on tracks 
- Added processor configurations for GBL/KF performance studies
- Modifies TrackAnaProcessor to make track performance studies using truth and retrieve KalmanTracks 
- Tracking processor fills truthTracks if doTruth is set to true. Additionally fills the track momentum using the bfield (as user defined parameter. Dangerous now, but trackData now stores momentum too)
- VertexAnaProcessor makes plots with more specific names: useful when running more than 1 Ana Processor at the same time. 