### PR TITLE
Update to Bump Hunter Code

### DIFF
--- a/analysis/include/BumpHunter.h
+++ b/analysis/include/BumpHunter.h
@@ -100,7 +100,7 @@ class BumpHunter {
         void getUpperLimitPower(TH1* histogram, HpsFitResult* result);
         
         /** */
-        std::vector<TH1*> generateToys(TH1* histogram, double n_toys, int seed, int toy_sig_samples, int bkg_mult = 1);
+        std::vector<TH1*> generateToys(TH1* histogram, double n_toys, int seed, int toy_sig_samples, int bkg_mult = 1, TH1* signal_hist = nullptr);
         
     private:
         /**

--- a/analysis/include/BumpHunter.h
+++ b/analysis/include/BumpHunter.h
@@ -48,7 +48,7 @@ class BumpHunter {
         };
         
         /** Default Constructor */
-        BumpHunter(BkgModel model, int poly_order, int res_factor, bool asymptotic_limit = true);
+        BumpHunter(BkgModel model, int poly_order, int res_factor, double res_scale = 1.56, bool asymptotic_limit = true);
         
         /** Destructor */
         ~BumpHunter();
@@ -115,7 +115,8 @@ class BumpHunter {
             //return 0.0389938364847*mass - 0.0000713783511061; // ideal
             //return 0.0501460737193*mass - 0.0000917925595224; // scaled to moller mass from data
             //return 0.0532190838657*mass - 0.0000922283032152; // scaled to moller mass + sys
-            return 1.56*(0.000955 - 0.004198 * mass + 0.2367 * mass * mass - 0.7009 * mass * mass * mass);
+            //return res_scale_*(0.000955 - 0.004198 * mass + 0.2367 * mass * mass - 0.7009 * mass * mass * mass);
+            return res_scale_ * (0.000379509 + (0.0416842 * mass) - (0.271364 * mass * mass) + (3.49537 * mass * mass * mass) - (11.1153 * mass * mass * mass * mass));
         };
         
         /**
@@ -179,6 +180,9 @@ class BumpHunter {
         
         /** Polynomial order used to model the background. */
         int poly_order_{0};
+
+        /** The scaling factor for the mass resolution. */
+        double res_scale_{1.56};
         
         /** 
          * Flag denoting if application should run in batch mode.  If set to 

--- a/analysis/include/BumpHunter.h
+++ b/analysis/include/BumpHunter.h
@@ -48,7 +48,7 @@ class BumpHunter {
         };
         
         /** Default Constructor */
-        BumpHunter(BkgModel model, int poly_order, int res_factor, double res_scale = 1.56, bool asymptotic_limit = true);
+        BumpHunter(BkgModel model, int poly_order, int res_factor, double res_scale = 1.00, bool asymptotic_limit = true);
         
         /** Destructor */
         ~BumpHunter();

--- a/analysis/include/BumpHunter.h
+++ b/analysis/include/BumpHunter.h
@@ -181,8 +181,9 @@ class BumpHunter {
         /** Polynomial order used to model the background. */
         int poly_order_{0};
 
-        /** The scaling factor for the mass resolution. */
-        double res_scale_{1.56};
+        /** The scaling factor for the mass resolution. Was 1.56 for Sebouh's, should 1.00 for Rafo's. */
+        //double res_scale_{1.56};
+        double res_scale_{1.00};
         
         /** 
          * Flag denoting if application should run in batch mode.  If set to 

--- a/analysis/src/BumpHunter.cxx
+++ b/analysis/src/BumpHunter.cxx
@@ -387,7 +387,7 @@ void BumpHunter::getUpperLimitPower(TH1* histogram, HpsFitResult* result) {
     }
 }
 
-std::vector<TH1*> BumpHunter::generateToys(TH1* histogram, double n_toys, int seed, int toy_sig_samples, int bkg_mult) {
+std::vector<TH1*> BumpHunter::generateToys(TH1* histogram, double n_toys, int seed, int toy_sig_samples, int bkg_mult, TH1* signal_hist) {
     gRandom->SetSeed(seed);
     
     TF1* bkg_toys = histogram->GetFunction("bkg_toys");
@@ -406,7 +406,9 @@ std::vector<TH1*> BumpHunter::generateToys(TH1* histogram, double n_toys, int se
             hist->Fill(bkg_toys->GetRandom(window_start_, window_end_));
         }
         for(int i = 0; i < toy_sig_samples; i++) {
-            double sig_sample = sig_toys->GetRandom(window_start_, window_end_);
+            double sig_sample = 0;
+            if(signal_hist != NULL) { sig_sample = signal_hist->GetRandom(); }
+            else { sig_sample = sig_toys->GetRandom(window_start_, window_end_); }
             hist->Fill(sig_sample);
         }
         hists.push_back(hist); 

--- a/analysis/src/BumpHunter.cxx
+++ b/analysis/src/BumpHunter.cxx
@@ -11,11 +11,12 @@
 
 #include "BumpHunter.h"
 
-BumpHunter::BumpHunter(BkgModel model, int poly_order, int res_factor, bool asymptotic_limit)
+BumpHunter::BumpHunter(BkgModel model, int poly_order, int res_factor, double res_scale, bool asymptotic_limit)
     : ofs(nullptr),
       res_factor_(res_factor), 
       poly_order_(poly_order),
-      asymptotic_limit_(asymptotic_limit) { }
+      asymptotic_limit_(asymptotic_limit),
+      res_scale_(res_scale) { }
 
 BumpHunter::~BumpHunter() { }
 

--- a/processors/config/bhToys_cfg.py
+++ b/processors/config/bhToys_cfg.py
@@ -18,6 +18,10 @@ parser.add_option("-s", "--spec", type="string", dest="mass_spec",
 parser.add_option("-a", "--sig", type="int", dest="toy_sig_samples",
         help="Number of signal events to add to toy models.", metavar="toy_sig_samples",
         default=0)
+parser.add_option("-af", "--sig_file", type="string", dest="signal_shape_h_file",
+        help="Name of the file containing the signal shape injection histogram.", metavar="signal_shape_h_file");
+parser.add_option("-ah", "--sig_hist", type="string", dest="signal_shape_h_name",
+        help="Name of the signal shape injection histogram.", metavar="signal_shape_h_name");
 parser.add_option("-b", "--bkg", type="int", dest="toy_bkg_mult",
         help="Number of toy background events in units of the integral of the input distribution.",
         metavar="toy_bkg_mult", default=1)

--- a/processors/config/bhToys_cfg.py
+++ b/processors/config/bhToys_cfg.py
@@ -18,13 +18,15 @@ parser.add_option("-s", "--spec", type="string", dest="mass_spec",
 parser.add_option("-a", "--sig", type="int", dest="toy_sig_samples",
         help="Number of signal events to add to toy models.", metavar="toy_sig_samples",
         default=0)
-parser.add_option("-af", "--sig_file", type="string", dest="signal_shape_h_file",
-        help="Name of the file containing the signal shape injection histogram.", metavar="signal_shape_h_file");
-parser.add_option("-ah", "--sig_hist", type="string", dest="signal_shape_h_name",
-        help="Name of the signal shape injection histogram.", metavar="signal_shape_h_name");
+parser.add_option("-f", "--sig_file", type="string", dest="signal_shape_h_file",
+        help="Name of the file containing the signal shape injection histogram.", metavar="signal_shape_h_file", default="")
+parser.add_option("-g", "--sig_hist", type="string", dest="signal_shape_h_name",
+        help="Name of the signal shape injection histogram.", metavar="signal_shape_h_name", default="")
 parser.add_option("-b", "--bkg", type="int", dest="toy_bkg_mult",
         help="Number of toy background events in units of the integral of the input distribution.",
         metavar="toy_bkg_mult", default=1)
+parser.add_option("-r", "--res_scale", type="float", dest="res_scale",
+        help="Factor by which to scale the mass resolution.", metavar="res_scale", default=1.56)
 (options, args) = parser.parse_args()
 
 # Use the input file to set the output file name
@@ -32,7 +34,8 @@ histo_file = options.inFilename
 mass_hypo = options.mass_hypo/1000.0
 poly_order = options.poly_order
 win_factor = options.win_factor
-toy_file = '%s/bhToys_m%iw%ip%is%i.root'%(options.outDir, options.mass_hypo, win_factor, poly_order, options.toy_sig_samples)
+# toy_file = '%s/bhToys_m%iw%ip%is%i.root'%(options.outDir, options.mass_hypo, win_factor, poly_order, options.toy_sig_samples)
+toy_file = '%s/bhToys_m%iw%ip%ir%is%i.root'%(options.outDir, options.mass_hypo, win_factor, poly_order, int(options.res_scale * 100), options.toy_sig_samples)
 
 print('Histo file: %s' % histo_file)
 print('Toy file: %s' % toy_file)
@@ -62,8 +65,11 @@ bhtoys.parameters["poly_order"] = poly_order
 bhtoys.parameters["win_factor"] = win_factor
 bhtoys.parameters["seed"] = 0
 bhtoys.parameters["nToys"] = options.nToys
-bhtoys.parameters["toy_sig_samples"] = options.toy_sig_samples;
-bhtoys.parameters["toy_bkg_mult"] = options.toy_bkg_mult;
+bhtoys.parameters["toy_sig_samples"] = options.toy_sig_samples
+bhtoys.parameters["toy_bkg_mult"] = options.toy_bkg_mult
+bhtoys.parameters["res_scale"] = options.res_scale
+bhtoys.parameters["signal_shape_h_name"] = options.signal_shape_h_name
+bhtoys.parameters["signal_shape_h_file"] = options.signal_shape_h_file
 
 # Sequence which the processors will run.
 p.sequence = [bhtoys]

--- a/processors/include/BhToysHistoProcessor.h
+++ b/processors/include/BhToysHistoProcessor.h
@@ -53,6 +53,17 @@ class BhToysHistoProcessor : public Processor {
         // The mass spectrum to fit
         TH1* mass_spec_h{nullptr};
 
+        // The signal shape histogram name to use, if defined.
+        //std::string* signal_shape_h_name_{"bhTight/bhTight_vtx_InvM_h"};
+        std::string* signal_shape_h_name_{nullptr};
+
+        // The signal shpae histogram file path, if defined.
+        //std::string* signal_shape_h_file_{"/volatile/hallb/hps/mccarty/anaBhAp100.root"};
+        std::string* signal_shape_h_file_{nullptr};
+
+        // The signal shape histogram to use.
+        TH1* signal_shape_h_{nullptr};
+
         // The signal hypothesis to use in the fit.
         double mass_hypo_{100.0};
         

--- a/processors/include/BhToysHistoProcessor.h
+++ b/processors/include/BhToysHistoProcessor.h
@@ -90,7 +90,7 @@ class BhToysHistoProcessor : public Processor {
         int bkg_mult_{1};
 
         // The factor by which to scale the mass resolution function.
-        double res_scale_{1.56};
+        double res_scale_{1.00};
         
         // Whether to use the asymptotic upper limit or the power constrained. Defaults to asymptotic.
         bool asymptotic_limit_{true};

--- a/processors/include/BhToysHistoProcessor.h
+++ b/processors/include/BhToysHistoProcessor.h
@@ -55,11 +55,11 @@ class BhToysHistoProcessor : public Processor {
 
         // The signal shape histogram name to use, if defined.
         //std::string* signal_shape_h_name_{"bhTight/bhTight_vtx_InvM_h"};
-        std::string* signal_shape_h_name_{nullptr};
+        std::string signal_shape_h_name_{""};
 
         // The signal shpae histogram file path, if defined.
         //std::string* signal_shape_h_file_{"/volatile/hallb/hps/mccarty/anaBhAp100.root"};
-        std::string* signal_shape_h_file_{nullptr};
+        std::string signal_shape_h_file_{""};
 
         // The signal shape histogram to use.
         TH1* signal_shape_h_{nullptr};
@@ -88,6 +88,9 @@ class BhToysHistoProcessor : public Processor {
         // of the invariant mass distribution. The number of events may be modified
         // by a multiplicative factor.
         int bkg_mult_{1};
+
+        // The factor by which to scale the mass resolution function.
+        double res_scale_{1.56};
         
         // Whether to use the asymptotic upper limit or the power constrained. Defaults to asymptotic.
         bool asymptotic_limit_{true};

--- a/processors/src/BhToysHistoProcessor.cxx
+++ b/processors/src/BhToysHistoProcessor.cxx
@@ -15,15 +15,17 @@ BhToysHistoProcessor::~BhToysHistoProcessor() { }
 void BhToysHistoProcessor::configure(const ParameterSet& parameters) {
     std::cout << "Configuring BhToysHistoProcessor" << std::endl;
     try {
-        debug_           = parameters.getInteger("debug");
-        massSpectrum_    = parameters.getString("massSpectrum");
-        mass_hypo_       = parameters.getDouble("mass_hypo");
-        win_factor_      = parameters.getInteger("win_factor");
-        poly_order_      = parameters.getInteger("poly_order");
-        seed_            = parameters.getInteger("seed");
-        nToys_           = parameters.getInteger("nToys");
-        toy_sig_samples_ = parameters.getInteger("toy_sig_samples");
-        bkg_mult_        = parameters.getInteger("toy_bkg_mult");
+        debug_               = parameters.getInteger("debug");
+        massSpectrum_        = parameters.getString("massSpectrum");
+        mass_hypo_           = parameters.getDouble("mass_hypo");
+        win_factor_          = parameters.getInteger("win_factor");
+        poly_order_          = parameters.getInteger("poly_order");
+        seed_                = parameters.getInteger("seed");
+        nToys_               = parameters.getInteger("nToys");
+        toy_sig_samples_     = parameters.getInteger("toy_sig_samples");
+        bkg_mult_            = parameters.getInteger("toy_bkg_mult");
+        //signal_shape_h_name_ = parameters.getString("signal_shape_h_name");
+        //signal_shape_h_file_ = parameters.getString("signal_shape_h_file");
         //asymptotic_limit_ = parameters.getBoolean("asymptoticLimit");
     } catch(std::runtime_error& error) {
         std::cout << error.what() << std::endl;
@@ -37,6 +39,12 @@ void BhToysHistoProcessor::initialize(std::string inFilename, std::string outFil
     // Get mass spectrum from file
     mass_spec_h = (TH1*) inF_->Get(massSpectrum_.c_str());
 
+    // Initialize the signal histogram, if a file name and histogram name are provided.
+    if(signal_shape_h_file_ != NULL && signal_shape_h_name_ != NULL) {
+        TFile *file = new TFile(signal_shape_h_file_->c_str());
+        signal_shape_h_ = (TH1*) file->Get(signal_shape_h_name_->c_str());
+    }
+    
     // Init bump hunter manager
     bump_hunter_ = new BumpHunter(bkg_model_, poly_order_, win_factor_, asymptotic_limit_);
     bump_hunter_->setBounds(mass_spec_h->GetXaxis()->GetBinUpEdge(mass_spec_h->FindFirstBinAbove()),
@@ -153,8 +161,13 @@ bool BhToysHistoProcessor::process() {
     if(nToys_ > 0) {
         std::cout << "Generating " << nToys_ << " Toys" << std::endl;
         std::cout << "    Signal Injection      :: " << toy_sig_samples_ << std::endl;
+        if(signal_shape_h_ != NULL) {
+            std::cout << "    Signal Shape          :: " << signal_shape_h_name_->c_str() << std::endl;
+        } else {
+            std::cout << "    Signal Shape          :: Gaussian" << std::endl;
+        }
         std::cout << "    Background Multiplier :: " << bkg_mult_ << std::endl;
-        std::vector<TH1*> toys_hist = bump_hunter_->generateToys(mass_spec_h, nToys_, seed_, toy_sig_samples_, bkg_mult_); 
+        std::vector<TH1*> toys_hist = bump_hunter_->generateToys(mass_spec_h, nToys_, seed_, toy_sig_samples_, bkg_mult_, signal_shape_h_);
 
         int toyFitN = 0;
         for(TH1* hist : toys_hist) {

--- a/processors/src/BhToysHistoProcessor.cxx
+++ b/processors/src/BhToysHistoProcessor.cxx
@@ -71,6 +71,8 @@ void BhToysHistoProcessor::initialize(std::string inFilename, std::string outFil
     flat_tuple_->addVariable("resolution_scale");
 
     flat_tuple_->addVariable("bkg_chi2_prob");
+    flat_tuple_->addVariable("bkgsig_chi2_prob");
+    flat_tuple_->addVariable("toyfit_chi2_prob");
     flat_tuple_->addVariable("bkg_edm");
     flat_tuple_->addVariable("bkg_minuit_status");
     flat_tuple_->addVariable("bkg_nll");
@@ -138,6 +140,8 @@ bool BhToysHistoProcessor::process() {
 
     // Set the Fit Results in the flat tuple
     flat_tuple_->setVariableValue("bkg_chi_prob",           bkg_result->Prob());
+    flat_tuple_->setVariableValue("bkgsig_chi2_prob",       sig_result->Prob());
+    flat_tuple_->setVariableValue("toyfit_chi2_prob",       result->getBkgToysFitResult()->Prob());
     flat_tuple_->setVariableValue("bkg_edm",                bkg_result->Edm());
     flat_tuple_->setVariableValue("bkg_minuit_status",      bkg_result->Status());
     flat_tuple_->setVariableValue("bkg_nll",                bkg_result->MinFcnValue());


### PR DESCRIPTION
A quick update to the bump hunter code. Changes include:

- The mass resolution may now be scaled by a decimal factor from the command line.
- A histogram file and histogram name may be provided as a signal injection source. Monte Carlo will be generated according to the histogram distribution instead of a Gaußian.
- The χ^2 values for the signal+background and toy generator fits are now persisted in the output ntuple.