### PR TITLE
Fixing a Typo

### DIFF
--- a/processors/src/BhToysHistoProcessor.cxx
+++ b/processors/src/BhToysHistoProcessor.cxx
@@ -157,7 +157,7 @@ bool BhToysHistoProcessor::process() {
     flat_tuple_->setVariableValue("bkg_model",              bkg_model_);
 
     // Set the Fit Results in the flat tuple
-    flat_tuple_->setVariableValue("bkg_chi_prob",           bkg_result->Prob());
+    flat_tuple_->setVariableValue("bkg_chi2_prob",          bkg_result->Prob());
     flat_tuple_->setVariableValue("bkgsig_chi2_prob",       sig_result->Prob());
     flat_tuple_->setVariableValue("toyfit_chi2_prob",       result->getBkgToysFitResult()->Prob());
     flat_tuple_->setVariableValue("bkg_edm",                bkg_result->Edm());


### PR DESCRIPTION
There was a typo that was preventing the chi^2 probability from being stored in the tuple correctly. This is now corrected.