### PR TITLE
Scripts and Bugs

### DIFF
--- a/plotUtils/bumpHunter_backgroundModelSelection.py
+++ b/plotUtils/bumpHunter_backgroundModelSelection.py
@@ -1,0 +1,269 @@
+#/bin/env python
+# coding: utf-8
+import os
+import re
+import math
+import ROOT as r
+import numpy as np
+import utilities as utils
+
+from optparse import OptionParser
+
+# Parse the command line options.
+parser = OptionParser()
+parser.add_option("-i", "--inputDir", type="string", dest="inputDir",
+    help="The directory containing the input ROOT files.", metavar="inputDir", default="toys/toys.root")
+parser.add_option("-r", "--windowRange", type="int", dest="windowRange",
+    help="The minimum size of the consecutive windows needed to select a model.", metavar="windowRange", default=5)
+(options, args) = parser.parse_args()
+
+# Track the x-value ranges.
+smallestWindow = 9999
+largestWindow = 0
+
+# Determine the window size range and instantiate the plot files.
+filenames = os.listdir(options.inputDir)
+for filename in filenames:
+    # Break the filename apart into its parameters.
+    params = re.split('[mwprs.]', filename)[2:7]
+    windowSize = int(params[1])
+    
+    # Track the window size range.
+    if(smallestWindow > windowSize): smallestWindow = windowSize
+    if(largestWindow < windowSize): largestWindow  = windowSize
+    pass
+
+print('Window Minimum: %i;   Window Maximum: %i' % (smallestWindow, largestWindow))
+
+# The signal error and the pull are stored in TProfile objects. These
+# must be instantiated before any other processing is done. Do this
+# here.
+sigError = { }
+sigPull = { }
+goodModels = { }
+filenames = os.listdir(options.inputDir)
+for filename in filenames:
+    # Break the filename apart into its parameters.
+    params = re.split('[mwprs.]', filename)[2:7]
+    mass       = int(params[0])
+    windowSize = int(params[1])
+    order      = int(params[2])
+    resScale   = int(params[3])
+    sigInj     = int(params[4])
+    
+    # Generate the unique key set name.
+    keyName = 'm%ip%ir%is%i' % (mass, order, resScale, sigInj)
+    
+    # If the key set name is not present in the pull and signal yield
+    # error dictionary, instantiate the plots.
+    if keyName not in sigPull:
+        # Determine the plot range.
+        winMin = smallestWindow - 0.5
+        winMax = largestWindow + 0.5
+        winBin = winMax - winMin
+        
+        # Create a TProfile for this key set.
+        sigError[keyName] = r.TProfile('%s_toyErr'  % (keyName), '%s Toy Signal Yield Error;Window Size (Mass Resolution);Signal Yield Error' % (keyName), int(winBin), float(winMin), float(winMax))
+        sigPull[keyName]  = r.TProfile('%s_toyPull' % (keyName), '%s Toy Pull;Window Size (Mass Resolution);Signal Pull'                      % (keyName), int(winBin), float(winMin), float(winMax))
+        sigError[keyName].SetErrorOption('s')
+        sigPull[keyName].SetErrorOption('s')
+    pass
+
+
+# Iterate over all files in the input directory. Skip those that are not
+# ROOT files.
+totalFiles = len(filenames)
+processedFiles = 0
+print("Processing data...")
+for filename in filenames:
+    processedFiles += 1
+    print('    %f%%' % (100.0 * processedFiles / totalFiles))
+    
+    # Exclude non-ROOT files.
+    if not filename.endswith(".root"): continue
+
+    # Get the current input file.
+    inFile = r.TFile(options.inputDir + filename)
+    tree = inFile.fit_toys
+
+    # Iterate over the "entries" in the file. There's really only ever
+    # one, but this forces Python to set everything up automatically.
+    for model in inFile.fit_toys:
+        # Get the dictionary keys.
+        order = model.poly_order
+        mass = int(model.mass_hypo * 1000)
+        windowSize = model.win_factor
+        sigInj = model.toy_sig_samples
+        resScale = int(model.resolution_scale * 100)
+        
+        # Model selection is only performed on data with no injected
+        # signal. Skip all others.
+        if(sigInj != 0): continue
+        print('        Processing Mass: %i;   Order: %i;   Window Size: %i;   Signal: %i' % (mass, order, windowSize, sigInj))
+        
+        # Get the key set unique name.
+        keyName = 'm%ip%ir%is%i' % (mass, order, resScale, sigInj)
+        
+        
+        
+        # The first model selection test is the background χ². This
+        # value must exceed 0.01. Get the χ² probability, check if it
+        # passes the threshold, and also store it so that it may be
+        # persisted into the output file. This is only performed for
+        # cases of no signal.
+        
+        # Get the χ² probability.
+        bkg_chi2 = float(model.bkg_chi2_prob)
+        
+        # Test whether the χ² passes the threshold test.
+        if(bkg_chi2 < 0.01):
+            print('            Background Chi2: %f;   Passes: False' % (float(bkg_chi2)))
+            continue
+        print('            Background Chi2: %f;   Passes: True' % (float(bkg_chi2)))
+        
+        
+        
+        # The second model selection test is the pull. The pull is
+        # determined by the pulls of each toy model that is generated
+        # and stored in the input data set. The average pull and its
+        # error are obtained by filling one of the TProfile objects
+        # defined previously, both so that they may be persisted, and
+        # also to make ROOT do all the math.
+        
+        # Populate the signal yield error and the pull plots. These
+        # are not persisted. They are used to force ROOT to calculate
+        # the relevant cut values.
+        for toy in range(len(model.toy_sig_yield)):
+            if model.toy_minuit_status[toy] > 0.0: continue
+            sigError[keyName].Fill(float(windowSize), float(model.toy_sig_yield_err[toy]))
+            sigPull[keyName].Fill(float(windowSize),  float(model.toy_sig_yield[toy] / model.toy_sig_yield_err[toy]))
+            pass
+        
+        # Get the pull and and pull uncertainty from the TProfile.
+        binN = sigPull[keyName].GetXaxis().FindBin(float(windowSize))
+        pullAvg = float(sigPull[keyName].GetBinContent(binN))
+        pullErr = float(sigPull[keyName].GetBinError(binN))
+        #pullEntries = float(sigPull[keyName].GetBinEntries(binN))
+        #sigma = math.sqrt(pullEntries) * pullErr
+            
+        # A model must be within 2σ of zero to be valid. Perform this
+        # test and track the result.
+        passesPull = False
+        if((pullAvg + (2 * pullErr) < 0) or (pullAvg - (2 * pullErr) > 0)):
+            print('            Pull: %f;   Err: %f;   Passes: False' % (float(pullAvg), float(pullErr)))
+            continue
+        print('            Pull: %f;   Err: %f;   Passes: True' % (float(pullAvg), float(pullErr)))
+        
+        
+        
+        # If this point is reached, the model is good.
+        if mass not in goodModels:
+            goodModels[mass] = { }
+        if order not in goodModels[mass]:
+            goodModels[mass][order] = [ ]
+        goodModels[mass][order].append(windowSize)
+        print("            Is Good Model: True")
+        pass
+    pass
+
+
+# Extract the preferred model. This is done independently for each
+# mass. For each model order, a range of consecutive, good windows
+# is searched. The window range must exceed a certain, user-defined
+# size to be valid. If found, this range is recorded for that order.
+# Once each order has been searched, the lowest order with a range is
+# considered and the window in the center of that range is selected.
+
+# Perform the procedure for each mass hypothesis.
+finalModelOrder = { }
+finalModelWindow = { }
+for mass in goodModels.keys():
+    print('Mass: %i MeV:' % (int(mass)))
+    
+    # Track the start and end of each range by model order.
+    startWindow = { }
+    endWindow = { }
+    
+    # Search for a range in each model order.
+    for order in goodModels[mass].keys():
+        print('    Order: %i MeV:' % (int(order)))
+        
+        # The window sizes must be sorted in order  to determine if
+        # they are consecutive.
+        windows = goodModels[mass][order]
+        windows.sort()
+        
+        # Search for a consecutive range.
+        startRange = -1
+        lastWindow = -1
+        nWindows = 0
+        for window in windows:
+            print('        Window %i' % (int(window)))
+            
+            # Handle the case where the current window is consecutive
+            # to the previous window.
+            if(window == lastWindow + 1):
+                nWindows += 1
+                lastWindow = window
+            
+            # Handle the case where the current window is not
+            # consecutive to the previous window, but a range of
+            # acceptable size has been found. In this case, the range
+            # is retained and no further ranges are considered.
+            elif(window != lastWindow + 1 and nWindows >= options.windowRange):
+                continue
+            
+            # Handle the case where either no windows have been yet
+            # processed, or the current window is not consecutive to
+            # the previous window and no acceptable range has been
+            # found yet.
+            else:
+                startRange = window
+                lastWindow = window
+                nWindows = 1
+            pass
+        pass
+        
+        print('        Start: %i;   End: %i' % (startRange, startRange + nWindows - 1))
+        
+        # Store the range start and end.
+        startWindow[order] = startRange
+        endWindow[order] = startRange + nWindows - 1
+    pass
+    
+    # Iterate over the ranges. An order is skipped if it is undefined
+    # and the next order is considered instead. The lowest order with
+    # a defined range is selected.
+    modelOrder = 100
+    modelWindow = -1
+    for order in startWindow.keys():
+        # Skip orders where the window range is too small.
+        if(endWindow[order] - startWindow[order] < options.windowRange): continue
+        
+        # Otherwise, if the model order is lower than the current
+        # selected range, replace it with this one.
+        if(order < modelOrder):
+            modelOrder = order
+            modelWindow = math.floor(startWindow[order] + ((endWindow[order] - startWindow[order]) / 2.0))
+        pass
+    
+    # If no proper range was found, just take whichever is largest
+    # and pick the middle value. If two ranges are equal in size,
+    # select the one with the smallest model order.
+    if(modelOrder == 100):
+        print("    Failed range test!! -- Using fallback method.")
+        largestRange = 0
+        for order in startWindow.keys():
+            if( ((endWindow[order] - startWindow[order]) > largestRange)  or ((endWindow[order] - startWindow[order]) == largestRange and order < modelOrder) ):
+                modelOrder = order
+                largestRange = endWindow[order] - startWindow[order]
+                modelWindow = math.floor(startWindow[order] + ((endWindow[order] - startWindow[order]) / 2.0))
+            pass
+    
+    print('    Model Order: %i;   Model Window: %i' % (modelOrder, modelWindow))
+    finalModelOrder[mass] = modelOrder
+    finalModelWindow[mass] = modelWindow
+
+# Print the dictionary definition for the selected models.
+for mass in finalModelOrder.keys():
+    print('%i   %i   %i' % (mass, finalModelOrder[mass], finalModelWindow[mass]))

--- a/plotUtils/bumpHunter_limitPlots.py
+++ b/plotUtils/bumpHunter_limitPlots.py
@@ -1,0 +1,255 @@
+#/bin/env python
+import math
+import numpy as np
+import ROOT as r
+import utilities as utils
+from optparse import OptionParser
+
+# Parse the command line options.
+parser = OptionParser()
+parser.add_option("-i", "--inputDir", type="string", dest="inputDir",
+    help="The directory containing the input ROOT files.", metavar="inputDir", default="toys/toys.root")
+parser.add_option("-o", "--outputFile", type="string", dest="outputFile",
+    help="Specify the output filename.", metavar="outputFile", default="testOut.root")
+parser.add_option("-p", "--prefix", type="string", dest="prefix",
+    help="Sets a prefix to prepend to all file names.", metavar="prefix", default="")
+parser.add_option("-d", "--plotdir", type="string", dest="plot_dir",
+    help="Sets the plot output directory.", metavar="plot_dir", default=".")
+parser.add_option("-m", "--selectedModels", type="string", dest="modelFile",
+    help="Sets the file containing the selected models for each mass.", metavar="modelFile", default="dat/selectedModels.dat")
+(options, args) = parser.parse_args()
+
+# Get the command line variables.
+prefix = options.prefix
+plotDirectory = options.plot_dir
+
+# Get the selected models. These should be in a file with
+# one mass per line of the form "Mass(MeV),Order,Window".
+# Thre should be no empty lines. These should ideally be
+# in ascending order. Unexpected behavior may otherwise
+# be observed.
+maxMass = -1
+minMass = 99999
+masses = [ ]
+polOrder = { }
+winSize = { }
+tmfFile = open(options.modelFile, "r")
+print("Reading selected models:")
+for line in tmfFile:
+    # Parse the line to get the selected model.
+    vals = line.split(",")
+    mass = int(vals[0])
+    order = int(vals[1])
+    window = int(vals[2])
+
+    # Add the mass to the list of masses that are to
+    # be processed.
+    masses.append(mass)
+
+    # Add the models to the appropriate maps.
+    polOrder[mass] = order
+    winSize[mass] = window
+    print('    Mass: %i;   Order: %i;   Window: %i' % (mass, order, window))
+    pass
+
+# Track the plot values.
+massFloats = []
+pSearch  = []
+pSearchG = []
+limitN   = []
+limitEps = []
+
+toyEpsilon = []
+toyEpsilonEU1 = []
+toyEpsilonEU2 = []
+toyEpsilonEL1 = []
+toyEpsilonEL2 = []
+
+# Make the output file.
+outFile = r.TFile(options.outputFile, 'RECREATE')
+
+# Plot pull for all models.
+sigPull = r.TProfile("limits_toyPull", "Toy Pull;Mass (MeV);Signal Pull", 150, 29.5, 179.5)
+sigPull.SetErrorOption('s')
+
+for mass in masses:
+    # Track the masses processed.
+    massFloats.append(float(mass))
+
+    # Load the input file.
+    inputFile = "%s/bhToys_m%iw%ip%ir100s0.root" % (options.inputDir, mass, winSize[mass], polOrder[mass])
+    inFile = r.TFile(inputFile)
+    #print('Reading file %s...' % inputFile)
+
+    # Calculate the radiative fraction.
+    gmass = mass / 1000.0
+    radFrac = (13603.8 * gmass * gmass * gmass * gmass * gmass) - (7779.47 * gmass * gmass * gmass * gmass) + (1669.07 * gmass * gmass * gmass) - (164.023 * gmass * gmass) + (7.07417 * gmass) - 0.0344651
+
+    # Calculate the epsilon squared limits.
+    for entry in inFile.fit_toys:
+        # Store the p-values for data.
+        pSearch.append(entry.p_value)
+        globalPValue = entry.p_value * 32.8481
+        if globalPValue > 1: globalPValue = 1
+        pSearchG.append(globalPValue)
+
+        # Get the signal yield and upper limit for data.
+        nSigFit = entry.sig_yield
+        if nSigFit < 0.0: nSigFit = 0.0
+        upLim = nSigFit + 1.64 * entry.sig_yield_err
+
+        # Store the upper limit and the epsilon squared upper limit
+        # for data.
+        limitN.append(upLim)
+        limitEps.append(2 * upLim / (411 * 3.14159 * mass * radFrac * 20 * entry.bkg_rate_mass_hypo))
+
+
+
+        # Get all values for signal yield, upper limit, and
+        # background rate from toys.
+        t_epsilon = [ ]
+        for toy in range(len(entry.toy_sig_yield)):
+            # Skip entries with bad fit stati.
+            if entry.toy_minuit_status[toy] > 0.0: continue
+
+            # The signal yield is zero if negative.
+            t_sigYieldVal = float(entry.toy_sig_yield[toy])
+            if t_sigYieldVal < 0.0: t_sigYieldVal = 0.0
+
+            # Plot the pull.
+            sigPull.Fill( float(mass), float((entry.toy_sig_yield[toy] - entry.toy_sig_samples) / entry.toy_sig_yield_err[toy]) )
+
+            # Get the upper limit and background rate.
+            t_upperLimit = float(t_sigYieldVal + 1.64 * entry.toy_sig_yield_err[toy])
+            t_bkgRate = float(entry.toy_bkg_rate_mass_hypo[toy])
+
+            # Calculate epsilon squared.
+            t_epsilon.append(2 * t_upperLimit / (411 * 3.14159 * mass * radFrac * 20 * t_bkgRate))
+            pass
+
+        # Make plots to store the epsilon squared values.
+        minBin = min(t_epsilon) * 0.75
+        maxBin = max(t_epsilon) * 1.25
+        epsPlot  = r.TH1D('m%i_epsilon' % (mass), '%i MeV #epsilon^{2};#epsilon^{2};Bin Count' % (mass), 100, minBin, maxBin)
+
+        for eps2 in t_epsilon:
+            epsPlot.Fill(eps2)
+            pass
+
+        # Save the plot.
+        outFile.cd()
+        epsPlot.Write()
+
+        # Sort the lists.
+        t_epsilon.sort()
+
+        # Get the indices for each value type.
+        i_mean = int(math.floor(len(t_epsilon) / 2))
+        i_1sigma_u = i_mean + int(math.floor(len(t_epsilon) * 0.341))
+        i_2sigma_u = i_mean + int(math.floor(len(t_epsilon) * 0.477))
+        i_1sigma_l = i_mean - int(math.floor(len(t_epsilon) * 0.341))
+        i_2sigma_l = i_mean - int(math.floor(len(t_epsilon) * 0.477))
+
+        # Calculate epsilon at this point and store the values.
+        toyEpsilon.append(t_epsilon[i_mean])
+        toyEpsilonEU1.append(t_epsilon[i_1sigma_u] - t_epsilon[i_mean])
+        toyEpsilonEU2.append(t_epsilon[i_2sigma_u] - t_epsilon[i_mean])
+        toyEpsilonEL1.append(t_epsilon[i_mean] - t_epsilon[i_1sigma_l])
+        toyEpsilonEL2.append(t_epsilon[i_mean] - t_epsilon[i_2sigma_l])
+
+        print('%i MeV :: %f;    %f <-- %f <-- %f --> %f --> %f' % ( mass, limitEps[len(limitEps) - 1], t_epsilon[i_2sigma_l], t_epsilon[i_1sigma_l], t_epsilon[i_mean], t_epsilon[i_1sigma_u], t_epsilon[i_2sigma_u] ));
+        pass
+    inFile.Close()
+    pass
+
+# Save and draw the pull plots.
+outFile.cd()
+utils.SetStyle()
+sigPull.SetLineColor(utils.colors[0])
+sigPull.SetLineWidth(3)
+sigPull.GetXaxis().SetTitleOffset(1.2)
+sigPull.GetYaxis().SetTitleOffset(1.0)
+sigPull.Write()
+
+utils.InsertText("",[],0.15,0.15)
+massPullCanvas = r.TCanvas("massPull_canvas", "massPull_canvas", 2500, 1000)
+sigPull.Draw()
+massPullCanvas.SaveAs('%s/%smassPull.png' % (plotDirectory, prefix))
+
+# Make the p-value plots.
+pSearch_g  = r.TGraph(len(massFloats), np.array(massFloats), np.array(pSearch))
+pSearch_g.SetName("pSearch_g")
+pSearch_g.SetTitle("pSearch_g;m_{A'} (MeV);Local p-Value")
+pSearchG_g  = r.TGraph(len(massFloats), np.array(massFloats), np.array(pSearchG))
+pSearchG_g.SetName("pSearchG_g")
+pSearchG_g.SetTitle("pSearch_g;m_{A'} (MeV);Global p-Value")
+
+utils.InsertText("",[],0.15,0.15)
+pValueCanvas = r.TCanvas("pValueCanvas", "pValueCanvas", 2500, 1000)
+pValueCanvas.SetLogy(1)
+pSearch_g.Draw()
+pValueCanvas.SaveAs('%s/%spValue.png' % (plotDirectory, prefix))
+
+# Make the upper limit of the signal yield plot.
+limitN_g   = r.TGraph(len(massFloats), np.array(massFloats), np.array(limitN))
+limitN_g.SetName("limitN_g")
+limitN_g.SetTitle("limitN_g;m_{A'} (MeV);N_{up}")
+
+utils.InsertText("",[],0.15,0.15)
+sigYieldCanvas = r.TCanvas("sigYieldCanvas", "sigYieldCanvas", 2500, 1000)
+sigYieldCanvas.SetLogy(1)
+limitN_g.Draw()
+sigYieldCanvas.SaveAs('%s/%ssigYieldUpperLimit.png' % (plotDirectory, prefix))
+
+# Make a canvas.
+canvas = r.TCanvas("ep2_canvas", "ep2_canvas", 2500, 1000)
+canvas.SetLogy(1)
+canvas.cd()
+
+# Make an array of zero for the "x error."
+xErrors = [ ]
+for entry in massFloats:
+    xErrors.append(0)
+    pass
+
+# Make the toy epsilon squared range plot.
+limitEps_s2_g = r.TGraphAsymmErrors(len(massFloats), np.array(massFloats), np.array(toyEpsilon), np.array(xErrors), np.array(xErrors), np.array(toyEpsilonEL2), np.array(toyEpsilonEU2))
+limitEps_s2_g.SetName("limitEps_s2_g")
+limitEps_s2_g.SetTitle("limitEps_s1_g;m_{A'} (MeV);#epsilon^{2}_{up}")
+limitEps_s2_g.SetFillColor(r.kOrange-2)
+limitEps_s2_g.GetYaxis().SetTitleOffset(1.4)
+limitEps_s2_g.Draw("a3")
+
+limitEps_s1_g = r.TGraphAsymmErrors(len(massFloats), np.array(massFloats), np.array(toyEpsilon), np.array(xErrors), np.array(xErrors), np.array(toyEpsilonEL1), np.array(toyEpsilonEU1))
+limitEps_s1_g.SetName("limitEps_s1_g")
+limitEps_s1_g.SetFillColor(r.kGreen-3)
+limitEps_s1_g.Draw("Same3l")
+
+# Make the data epsilon squared plot.
+limitEps_g = r.TGraph(len(massFloats), np.array(massFloats), np.array(limitEps))
+limitEps_g.SetName("limitEps_g")
+limitEps_g.SetLineWidth(3)
+limitEps_g.Draw("Same")
+
+# Make the toy median epsilon squared plot.
+limitEps_toy_g = r.TGraph(len(massFloats), np.array(massFloats), np.array(toyEpsilon))
+limitEps_toy_g.SetName("limitEps_toy_g")
+limitEps_toy_g.SetLineWidth(2)
+limitEps_toy_g.SetLineStyle(2)
+limitEps_toy_g.Draw("Same")
+
+# Save the epsilon limit plot.
+utils.InsertText("", [], 0.15, 0.15)
+canvas.SaveAs('%s/%sepsilonSquaredLimit.png' % (plotDirectory, prefix))
+canvas.Write()
+
+# Save the files.
+outFile.cd()
+pSearch_g.Write()
+pSearchG_g.Write()
+limitN_g.Write()
+limitEps_g.Write()
+limitEps_s1_g.Write()
+limitEps_s2_g.Write()
+limitEps_toy_g.Write()
+outFile.Close()

--- a/plotUtils/bumpHunter_limitPlots.py
+++ b/plotUtils/bumpHunter_limitPlots.py
@@ -28,8 +28,6 @@ plotDirectory = options.plot_dir
 # Thre should be no empty lines. These should ideally be
 # in ascending order. Unexpected behavior may otherwise
 # be observed.
-maxMass = -1
-minMass = 99999
 masses = [ ]
 polOrder = { }
 winSize = { }

--- a/plotUtils/bumpHunter_massResolutionScaleStudy.py
+++ b/plotUtils/bumpHunter_massResolutionScaleStudy.py
@@ -1,0 +1,356 @@
+#/bin/env python
+# coding: utf-8
+import os
+import re
+import math
+import ROOT as r
+import numpy as np
+import utilities as utils
+
+from optparse import OptionParser
+
+# Parse the command line options.
+parser = OptionParser()
+parser.add_option("-i", "--inputDir", type="string", dest="inputDir",
+    help="The directory containing the input ROOT files.", metavar="inputDir", default="toys/toys.root")
+parser.add_option("-o", "--outputFile", type="string", dest="outputFile",
+    help="Specify the output filename.", metavar="outputFile", default="testOut.root")
+parser.add_option("-p", "--prefix", type="string", dest="prefix",
+    help="Sets a prefix to prepend to all file names.", metavar="prefix", default="")
+parser.add_option("-d", "--plotdir", type="string", dest="plot_dir",
+    help="Sets the plot output directory.", metavar="plot_dir", default=".")
+parser.add_option("-f", "--truthFraction", type="string", dest="truthFracFile",
+    help="Sets the file containing the signal truth-matching fractions.", metavar="truthFracFile", default="dat/truthMatchFrac.dat")
+(options, args) = parser.parse_args()
+
+# Map the corrections for signal removal. This takes as an input
+# file where each line is of the form "Mass(MeV),Fraction". There
+# should be no spaces and should be one mass per line. No empty lines.
+truthMatchFrac = { }
+print("Defining signal truth-matching fraction:")
+tmfFile = open(options.truthFracFile, "r")
+for line in tmfFile:
+    vals = line.split(",")
+    mass = int(vals[0])
+    frac = float(vals[1])
+    truthMatchFrac[mass] = frac
+    print('    Mass: %i;   Fraction: %f' % (mass, frac))
+    pass
+
+# Get the command line variables.
+prefix = options.prefix
+plotDirectory = options.plot_dir
+
+# Track the x-value ranges.
+smallestWindow = 9999
+smallestSigInj = 99999999999
+largestWindow = 0
+largestSigInj = 0
+
+# Determine the window size range and instantiate the plot files.
+filenames = os.listdir(options.inputDir)
+for filename in filenames:
+    # Break the filename apart into its parameters.
+    params = re.split('[mwprs.]', filename)[2:7]
+    windowSize = int(params[1])
+    sigInj     = int(params[4])
+
+    # Track the window size range.
+    if(smallestWindow > windowSize): smallestWindow = windowSize
+    if(smallestSigInj > sigInj): smallestSigInj = windowSize
+    if(largestWindow < windowSize): largestWindow  = windowSize
+    if(largestSigInj < sigInj): largestSigInj  = sigInj
+    pass
+
+print('Window Minimum: %i;   Window Maximum: %i' % (smallestWindow, largestWindow))
+print('Signal Minimum: %i;   Signal Maximum: %i' % (smallestSigInj, largestSigInj))
+
+# The signal error and the pull are stored in TProfile objects. These
+# must be instantiated before any other processing is done. Do this
+# here.
+chi2Data = { }
+pullSigG = { }
+pullSigErrG = { }
+
+sigError = { }
+sigPull = { }
+filenames = os.listdir(options.inputDir)
+for filename in filenames:
+    # Break the filename apart into its parameters.
+    params = re.split('[mwprs.]', filename)[2:7]
+    mass       = int(params[0])
+    windowSize = int(params[1])
+    order      = int(params[2])
+    resScale   = int(params[3])
+    sigInj     = int(params[4])
+
+    # Generate the unique key set name.
+    keyName = 'm%ip%ir%is%i' % (mass, order, resScale, sigInj)
+
+    # If the key set name is not present in the pull and signal yield
+    # error dictionary, instantiate the plots.
+    if keyName not in sigPull:
+        # Determine the plot range.
+        winMin = smallestWindow - 0.5
+        winMax = largestWindow + 0.5
+        winBin = winMax - winMin
+
+        # Create a TProfile for this key set.
+        sigError[keyName] = r.TProfile('%s_toyErr'  % (keyName), '%s Toy Signal Yield Error;Window Size (Mass Resolution);Signal Yield Error' % (keyName), int(winBin), float(winMin), float(winMax))
+        sigPull[keyName]  = r.TProfile('%s_toyPull' % (keyName), '%s Toy Pull;Window Size (Mass Resolution);Signal Pull'                      % (keyName), int(winBin), float(winMin), float(winMax))
+        sigError[keyName].SetErrorOption('s')
+        sigPull[keyName].SetErrorOption('s')
+    pass
+
+
+# Iterate over all files in the input directory. Skip those that are not
+# ROOT files.
+totalFiles = len(filenames)
+processedFiles = 0
+print("Processing data...")
+for filename in filenames:
+    processedFiles += 1
+    print('    %f%%' % (100.0 * processedFiles / totalFiles))
+
+    # Exclude non-ROOT files.
+    if not filename.endswith(".root"): continue
+
+    # Get the current input file.
+    inFile = r.TFile(options.inputDir + filename)
+    tree = inFile.fit_toys
+
+    # Iterate over the "entries" in the file. There's really only ever
+    # one, but this forces Python to set everything up automatically.
+    for model in inFile.fit_toys:
+        # Get the dictionary keys.
+        order = model.poly_order
+        mass = int(model.mass_hypo * 1000)
+        windowSize = model.win_factor
+        sigInj = model.toy_sig_samples
+        resScale = int(model.resolution_scale * 100)
+        print('        Processing Mass: %i;   Order: %i;   Window Size: %i;   Signal: %i' % (mass, order, windowSize, sigInj))
+
+        # Get the key set unique name.
+        keyName = 'm%ip%ir%is%i' % (mass, order, resScale, sigInj)
+
+        # Collect the χ² data.
+        if(sigInj == 0):
+            # Get the χ² probability.
+            bkg_chi2 = float(model.bkg_chi2_prob)
+
+            # Map it to the current window size for this key set. If the
+            # key set is not defined yet, instantiate it.
+            if keyName not in chi2Data:
+                chi2Data[keyName] = { }
+            chi2Data[keyName][windowSize] = bkg_chi2
+
+        # Collect the signal yield and pull data.
+        nTotal = 0
+        nFailed = 0
+        for toy in range(len(model.toy_sig_yield)):
+            nTotal += 1
+            if model.toy_minuit_status[toy] > 0.0: continue
+            if model.toy_sig_yield_err[toy] == 0:
+                nFailed += 1
+                print('            Yield: %f;   RFrac: %f;   Signal: %i;   Error: %f' % (model.toy_sig_yield[toy], float(truthMatchFrac[mass]), model.toy_sig_samples, model.toy_sig_yield_err[toy]))
+                continue
+            sigError[keyName].Fill(float(windowSize), float(model.toy_sig_yield_err[toy]))
+            sigPull[keyName].Fill(float(windowSize),  float((model.toy_sig_yield[toy] - (float(truthMatchFrac[mass]) * model.toy_sig_samples)) / model.toy_sig_yield_err[toy]))
+            pass
+        print('            Failed: %i;   Total: %i;   Percent Failed: %f%%' % (nFailed, nTotal, 100.0 * nFailed / nTotal))
+
+        # Get the pull and and pull uncertainty from the TProfile.
+        binN = sigPull[keyName].GetXaxis().FindBin(float(windowSize))
+        pullAvg = float(sigPull[keyName].GetBinContent(binN))
+        pullErr = float(sigPull[keyName].GetBinError(binN))
+
+        # Store the pull as a function of signal injection.
+        pullSigGKey = 'm%ip%iw%i' % (mass, order, windowSize)
+        if pullSigGKey not in pullSigG:
+            pullSigG[pullSigGKey] = { }
+        if pullSigGKey not in pullSigErrG:
+            pullSigErrG[pullSigGKey] = { }
+        pullSigG[pullSigGKey][sigInj] = pullAvg
+        pullSigErrG[pullSigGKey][sigInj] = pullErr
+        pass
+    pass
+
+
+# Create the output file and output the plots.
+outFile = r.TFile(options.outputFile,'RECREATE')
+outFile.cd()
+
+# Set the plot style.
+utils.SetStyle()
+
+# Save the error and pull versus window size plots.
+for key in sigError.keys():
+    sigError[key].Write()
+    sigPull[key].Write()
+
+# Save the pull as a function of signal strength plots.
+fitSlope = { }
+fitSlopeErr = { }
+fitOffset = { }
+fitOffsetErr = { }
+for key in pullSigG:
+    print('\n\n%s' % key)
+
+    # Get the x-axis values. These are just the signal injection
+    # strength keys sorted in ascending order.
+    sigInjs = pullSigG[key].keys()
+    sigInjs.sort()
+
+    # Get the signal injection order.
+    logSigInj = [ ]
+    for sigInj in sigInjs:
+        if(sigInj == 0): logSigInj.append(0)
+        else: logSigInj.append(math.log(sigInj, 10))
+        pass
+
+    # Get the y-axis values. These are the pulls corresponding to the
+    # signal injection strength values.
+    pulls = [ ]
+    xErrs = [ ]
+    yErrs = [ ]
+    for sigInj in sigInjs:
+        pulls.append(pullSigG[key][sigInj])
+        xErrs.append(0)
+        yErrs.append(pullSigErrG[key][sigInj])
+        print('    Inj: %i;    Pull: %f' % (int(sigInj), float(pullSigG[key][sigInj])))
+        pass
+
+    # Create a TGraph to store the values.
+    pullSigGraph = r.TGraphErrors(len(pulls), np.array(sigInjs), np.array(pulls), np.array(xErrs), np.array(yErrs))
+    pullSigGraph.SetName('%s_injVSpull_g' % (key))
+    pullSigGraph.SetTitle('%s Pull vs. Signal Injection Strength;Signal Injection (Events);Pull' % (key))
+
+    pullLogSigGraph = r.TGraphErrors(len(pulls), np.array(logSigInj), np.array(pulls), np.array(xErrs), np.array(yErrs))
+    pullLogSigGraph.SetName('%s_loginjVSpull_g' % (key))
+    pullLogSigGraph.SetTitle('%s Pull vs. Log_{10}(Signal Injection Strength);Signal Injection (Events);Pull' % (key))
+
+    # Break the key apart into its components.
+    params = re.split('[mwp]', key)[1:]
+    mass = int(params[0])
+    order = int(params[1])
+    windowSize = int(params[2])
+
+    # Each TGraph should be fit with a linear fit function and then
+    # the slope stored as a function of window size for a given mass
+    # and order. Create a 1D fit function.
+    fitResult = pullSigGraph.Fit("pol1", "S+")
+    fitParams = fitResult.GetParams()
+    fitErrors = fitResult.GetErrors()
+    offset = fitParams[0]
+    offsetErr = fitErrors[0]
+    slope = fitParams[1]
+    slopeErr = fitErrors[1]
+
+    # Store the values.
+    valKey = 'm%io%i' % (mass, order)
+    if valKey not in fitSlope:
+        fitSlope[valKey] = { }
+        fitSlopeErr[valKey] = { }
+        fitOffset[valKey] = { }
+        fitOffsetErr[valKey] = { }
+    fitSlope[valKey][windowSize] = slope
+    fitSlopeErr[valKey][windowSize] = slopeErr
+    fitOffset[valKey][windowSize] = offset
+    fitOffsetErr[valKey][windowSize] = offsetErr
+
+    # Set the plot style.
+    plots = [ pullSigGraph, pullLogSigGraph ]
+    plotNames = [ "pullSig", "logPullSig" ]
+    for i in range(len(plots)):
+        plots[i].SetLineWidth(3)
+        plots[i].SetMarkerSize(3)
+        plots[i].SetMarkerStyle(20)
+        plots[i].GetYaxis().SetTitleOffset(0.60)
+
+        # Draw the plot and save it to a file.
+        canvas = r.TCanvas('%s_canvas' % (key), '%s_canvas' % (key), 2500, 1000)
+        plots[i].Draw("ap")
+        utils.InsertText("", [], 0.85, 0.15)
+        canvas.SaveAs('%s/%sm%io%iw%i_%s.png'%(plotDirectory, prefix, mass, order, windowSize, plotNames[i]))
+
+        # Save the graph.
+        plots[i].Write()
+        pass
+
+# Create the slope and offset graphs.
+for key in fitSlope:
+    # Get the x-axis values. These are just the window size keys
+    # sorted in ascending order.
+    windowSizes = [ ]
+    for windowSize in fitSlope[key].keys():
+        windowSizes.append(float(windowSize))
+    windowSizes.sort()
+
+    # Get the y-axis values. These are the fit parameters.
+    slopes = [ ]
+    slopeXErrs = [ ]
+    slopeYErrs = [ ]
+    offsets = [ ]
+    offsetYErrs = [ ]
+    for windowSize in windowSizes:
+        slopeXErrs.append(0.0)
+        slopes.append(float(fitSlope[key][windowSize]))
+        slopeYErrs.append(float(fitSlopeErr[key][windowSize]))
+        offsets.append(float(fitOffset[key][windowSize]))
+        offsetYErrs.append(float(fitOffsetErr[key][windowSize]))
+        pass
+
+    # DEBUG PRINT
+    print (key)
+    for i in range(len(windowSizes) - 1):
+        print('(%i, %f, %f)' % (windowSizes[i], slopes[i], offsets[i]))
+
+    # Create TGraph objects to store the values.
+    slopeGraph = r.TGraphErrors(len(slopes), np.array(windowSizes), np.array(slopes), np.array(slopeXErrs), np.array(slopeYErrs))
+    slopeGraph.SetName('%s_slope_g' % (key))
+    slopeGraph.SetTitle('%s Fit Slope vs. Window Size;Window Size (Mass Resolution);Slope' % (key))
+
+    offsetGraph = r.TGraphErrors(len(offsets), np.array(windowSizes), np.array(offsets), np.array(slopeXErrs), np.array(offsetYErrs))
+    offsetGraph.SetName('%s_offset_g' % (key))
+    offsetGraph.SetTitle('%s Fit Offset vs. Window Size;Window Size (Mass Resolution);Offset' % (key))
+
+    # Set the plot style.
+    slopeGraph.SetLineWidth(3)
+    slopeGraph.SetMarkerSize(2)
+    slopeGraph.SetMarkerStyle(20)
+    slopeGraph.GetYaxis().SetTitleOffset(0.60)
+
+    offsetGraph.SetLineWidth(3)
+    offsetGraph.SetMarkerSize(2)
+    offsetGraph.SetMarkerStyle(20)
+    offsetGraph.GetYaxis().SetTitleOffset(0.60)
+
+    # Draw the plot and save it to a file.
+    canvas = r.TCanvas('%s_canvas' % (key), '%s_canvas' % (key), 2500, 1000)
+    slopeGraph.Draw("ap")
+    utils.InsertText("", [], 0.15, 0.15)
+    canvas.SaveAs('%s/%s%s_slopeVSwindowSize.png'%(plotDirectory, prefix, key))
+
+    # Save the graphs.
+    outFile.cd()
+    slopeGraph.Write()
+    offsetGraph.Write()
+
+# Save the χ² probabilities.
+for key in chi2Data.keys():
+    # Create two lists - one containing the window sizes and one
+    # containing the χ² probabilities.
+    windowSizes = chi2Data[key].keys()
+    windowSizes.sort()
+    chi2s = [ ]
+    for windowSize in windowSizes:
+        chi2s.append(chi2Data[key][windowSize])
+
+    # Create a TGraph to store the χ² data.
+    bkgChi2Graph = r.TGraph(len(chi2s), np.array(windowSizes), np.array(chi2s))
+    bkgChi2Graph.SetName('%s_bkgChi2_g' % (key))
+    bkgChi2Graph.SetTitle('%s Background #chi^{2} vs. Window Size;Window Size (Mass Resolution);#chi^{2}' % (key))
+    bkgChi2Graph.Write()
+
+# Close the output file.
+outFile.Close()

--- a/plotUtils/bumpHunter_summaryPlots.py
+++ b/plotUtils/bumpHunter_summaryPlots.py
@@ -33,7 +33,7 @@ for filename in filenames:
     # Break the filename apart into its parameters.
     params = re.split('[mwprs.]', filename)[2:7]
     windowSize = int(params[1])
-    
+
     # Track the window size range.
     if(smallestWindow > windowSize): smallestWindow = windowSize
     if(largestWindow < windowSize): largestWindow = windowSize
@@ -54,21 +54,24 @@ for filename in filenames:
     order      = int(params[2])
     resScale   = int(params[3])
     sigInj     = int(params[4])
-    
+
     # Generate the unique key set name for the plot.
     keyName = 'm%ip%ir%is%i' % (mass, order, resScale, sigInj)
-    
+
     # If the plot dictionaries lack this key, create a new plot.
     if keyName not in sigYield:
         # Determine the plot range.
         winMin = smallestWindow - 0.5
         winMax = largestWindow + 0.5
         winBin = winMax - winMin
-        
+
         # Create a TProfile for this key set.
         sigYield[keyName] = r.TProfile('%s_toySig'  % (keyName), '%s Toy Signal Yield;Window Size (Mass Resolution);Signal Yield'             % (keyName), int(winBin), float(winMin), float(winMax))
         sigError[keyName] = r.TProfile('%s_toyErr'  % (keyName), '%s Toy Signal Yield Error;Window Size (Mass Resolution);Signal Yield Error' % (keyName), int(winBin), float(winMin), float(winMax))
         sigPull[keyName]  = r.TProfile('%s_toyPull' % (keyName), '%s Toy Pull;Window Size (Mass Resolution);Signal Pull'                      % (keyName), int(winBin), float(winMin), float(winMax))
+        sigYield[keyName].SetErrorOption('s')
+        sigError[keyName].SetErrorOption('s')
+        sigPull[keyName].SetErrorOption('s')
     pass
 
 
@@ -80,7 +83,7 @@ print("Processing data...")
 for filename in filenames:
     processedFiles += 1
     print('    %f%%' % (100.0 * processedFiles / totalFiles))
-    
+
     # Exclude non-ROOT files.
     if not filename.endswith(".root"): continue
 
@@ -97,10 +100,10 @@ for filename in filenames:
         windowSize = model.win_factor
         sigInject = model.toy_sig_samples
         resScale = int(model.resolution_scale * 100)
-        
+
         # Get the key set unique name.
         keyName = 'm%ip%ir%is%i' % (mass, order, resScale, sigInject)
-        
+
         # Get the tracked values.
         for toy in range(len(model.toy_sig_yield)):
             if model.toy_minuit_status[toy] > 0.0: continue
@@ -137,7 +140,7 @@ for keyName in sigYield.keys():
         plot.SetLineWidth(3)
         plot.GetXaxis().SetTitleOffset(1.2)
         plot.GetYaxis().SetTitleOffset(1.0)
-    
+
     # The pull plot should have a special range.
     pullPlot.GetYaxis().SetRangeUser(-5, 5)
 
@@ -151,12 +154,12 @@ for keyName in sigYield.keys():
     yieldPlot.Draw()
     utils.InsertText("",[],0.15,0.15)
     yieldCanvas.SaveAs('%s/%s%s_yield.png' % (plotDirectory, prefix, keyName))
-    
+
     errorCanvas.cd()
     errorPlot.Draw()
     utils.InsertText("",[],0.15,0.15)
     errorCanvas.SaveAs('%s/%s%s_error.png' % (plotDirectory, prefix, keyName))
-    
+
     pullCanvas.cd()
     pullPlot.Draw()
     utils.InsertText("",[],0.15,0.15)

--- a/processors/config/bhToys_cfg.py
+++ b/processors/config/bhToys_cfg.py
@@ -9,7 +9,7 @@ parser.add_option("-m", "--mass", type="int", dest="mass_hypo",
 parser.add_option("-p", "--poly", type="int", dest="poly_order",
         help="Polynomial order of background model.", metavar="poly_order", default=3)
 parser.add_option("-P", "--toy_poly", type="int", dest="toy_poly_order",
-        help="Polynomial order of toy generator fit.", metavar="toy_poly_order", default=5)
+        help="Polynomial order of toy generator fit.", metavar="toy_poly_order", default=-1)
 parser.add_option("-w", "--win", type="int", dest="win_factor",
         help="Window factor for determining fit window size.", metavar="win_factor", default=11)
 parser.add_option("-N", "--toys", type="int", dest="nToys",

--- a/processors/include/BhToysHistoProcessor.h
+++ b/processors/include/BhToysHistoProcessor.h
@@ -68,7 +68,7 @@ class BhToysHistoProcessor : public Processor {
         int poly_order_{3};
 
         // Order of polynomial used to create the toy generator function.
-        int toy_poly_order_{5};
+        int toy_poly_order_{-1};
 
         // The factor that determines the size of the mass window as
         //      window_size = (mass_resolution*win_factor)

--- a/processors/src/BhToysHistoProcessor.cxx
+++ b/processors/src/BhToysHistoProcessor.cxx
@@ -68,6 +68,9 @@ void BhToysHistoProcessor::initialize(std::string inFilename, std::string outFil
                 break;
         default: bkg_fit_model = FitFunction::BkgModel::EXP_CHEBYSHEV;
     }
+
+    // If the toy fit order is -1, it is undefined.
+    if(toy_poly_order_ == -1) { toy_poly_order_ = poly_order_ + 2; }
     
     // Init bump hunter manager
     bump_hunter_ = new BumpHunter(bkg_fit_model, poly_order_, toy_poly_order_, win_factor_, res_scale_, asymptotic_limit_);


### PR DESCRIPTION
Add additional scripts used in the resonance search analysis. These include:
- A script to select the models.
- A script to produce the plots from the mass resolution variance study.
- A script to produce the limit plots and pull vs. mass plot.

Also corrected two bugs:
1. The summary plots incorrectly used root _N_ error instead of RMS error. This is now corrected.
2. The resonance search code did not correctly default O(_N_ + 2) if no order was manually specified. This has now been corrected.