### PR TITLE
Change the CMakeLists to be compatible with cmake3 and root 6.20.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 # minimum cmake version
 cmake_minimum_required(VERSION 3.0)
 
+project(hpstr)
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD 14)

--- a/event/CMakeLists.txt
+++ b/event/CMakeLists.txt
@@ -6,7 +6,8 @@ module(
     EXTERNAL_DEPENDENCIES ROOT LCIO 
 )
 
-root_generate_dictionary(EventDict ${event_INCLUDE_DIR}/EventDef.h MODULE ${PROJECT_NAME} LINKDEF ${event_INCLUDE_DIR}/EventLinkDef.h)
+#root_generate_dictionary(EventDict ${event_INCLUDE_DIR}/EventDef.h MODULE ${PROJECT_NAME} LINKDEF ${event_INCLUDE_DIR}/EventLinkDef.h)
+root_generate_dictionary(EventDict ${event_INCLUDE_DIR}/EventDef.h LINKDEF ${event_INCLUDE_DIR}/EventLinkDef.h)
 
 # install ROOT pcm file
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib${PROJECT_NAME}_rdict.pcm DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)


### PR DESCRIPTION
Fixes the compilation issue for root 6.20.x

Tested on MacOS for root 6.18.05 and 6.20.05 and "master" (6.21.01).
Tested on Centos 7 for root 6.18.05 and 6.20.05

