### PR TITLE
Add the EcalHits back into standard recoTuple

### DIFF
--- a/processors/config/recoTuple_cfg.py
+++ b/processors/config/recoTuple_cfg.py
@@ -72,7 +72,7 @@ track.parameters["rawhitCollRoot"] = '' #'SVTRawHitsOnTrack'
 #ECalData
 ecal.parameters["debug"] = 0 
 ecal.parameters["hitCollLcio"] = 'EcalCalHits'
-ecal.parameters["hitCollRoot"] = ''#'RecoEcalHits'
+ecal.parameters["hitCollRoot"] = 'RecoEcalHits'
 ecal.parameters["clusCollLcio"] = "EcalClustersCorr"
 ecal.parameters["clusCollRoot"] = "RecoEcalClusters"
 


### PR DESCRIPTION
We should keep the standard configurations of  the config files as universally applicable as possible.
