### PR TITLE
Copy both rdict and rootmap to library, make sure naming is correct. …

### DIFF
--- a/event/CMakeLists.txt
+++ b/event/CMakeLists.txt
@@ -2,12 +2,13 @@
 # Declare processing module
 module( 
     NAME event 
-    EXTRA_SOURCES EventDict.cxx
+#    EXTRA_SOURCES EventDict.cxx
     EXTERNAL_DEPENDENCIES ROOT LCIO 
 )
 
 #root_generate_dictionary(EventDict ${event_INCLUDE_DIR}/EventDef.h MODULE ${PROJECT_NAME} LINKDEF ${event_INCLUDE_DIR}/EventLinkDef.h)
-root_generate_dictionary(EventDict ${event_INCLUDE_DIR}/EventDef.h LINKDEF ${event_INCLUDE_DIR}/EventLinkDef.h)
+root_generate_dictionary(EventDict ${event_INCLUDE_DIR}/EventDef.h MODULE ${PROJECT_NAME}  LINKDEF ${event_INCLUDE_DIR}/EventLinkDef.h)
 
 # install ROOT pcm file
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libEventDict_rdict.pcm DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libevent_rdict.pcm DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libevent.rootmap DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)


### PR DESCRIPTION
…Works for root 6.
Tested on: MacOS (clang), Centos 7 (gcc 9.3, cxx17), Ubuntu 20.04 (gcc 9.3, cxx17)

This will probably break things for root 5, but I think everyone is past root 5,... right?