### PR TITLE
Upgrade to the Resonance Search

### DIFF
--- a/processors/src/BhToysHistoProcessor.cxx
+++ b/processors/src/BhToysHistoProcessor.cxx
@@ -70,7 +70,7 @@ void BhToysHistoProcessor::initialize(std::string inFilename, std::string outFil
     }
 
     // If the toy fit order is -1, it is undefined.
-    if(toy_poly_order_ == -1) { toy_poly_order_ = poly_order_ + 2; }
+    if(toy_poly_order_ == -1) { toy_poly_order_ = poly_order_; }
     
     // Init bump hunter manager
     bump_hunter_ = new BumpHunter(bkg_fit_model, poly_order_, toy_poly_order_, win_factor_, res_scale_, asymptotic_limit_);


### PR DESCRIPTION
Fixed the toy generator polynomial so that it now defaults to the same order as the background-only fit polynomial, rather than O(N + 2).

Upgraded the full systematics processor so that it properly generates multiple events in the TTree for each toy fit set, instead of creating a new tuple for each one.