### PR TITLE
some corrections

### DIFF
--- a/event/include/CalCluster.h
+++ b/event/include/CalCluster.h
@@ -47,6 +47,12 @@ class CalCluster : public TObject {
         TRefArray* getHits() const { return hits_; }
 
         /**
+         * @return number of references to the calorimeter hits composing
+         * this cluster.
+         */
+        int getNHits() const { return n_hits_; }
+
+        /**
          * Set the position of the calorimeter cluster.
          *
          * @param position : The position of the calorimeter cluster

--- a/processing/src/HpsEventFile.cxx
+++ b/processing/src/HpsEventFile.cxx
@@ -31,12 +31,13 @@ void HpsEventFile::close() {
 
 bool HpsEventFile::nextEvent() {
   
-  ++entry_;
-  if (entry_>maxEntries_)
+  if (entry_ > maxEntries_ - 1)
     return false;
 
   //TODO Really don't like having the tree associated to the event object. Should be associated to the EventFile.
   intree_->GetEntry(entry_);
+
+  ++entry_;
   
   return true;
 } 

--- a/processing/src/HpsEventFile.cxx
+++ b/processing/src/HpsEventFile.cxx
@@ -35,9 +35,7 @@ bool HpsEventFile::nextEvent() {
     return false;
 
   //TODO Really don't like having the tree associated to the event object. Should be associated to the EventFile.
-  intree_->GetEntry(entry_);
-
-  ++entry_;
+  intree_->GetEntry(entry_++);
   
   return true;
 } 

--- a/processors/src/EventProcessor.cxx
+++ b/processors/src/EventProcessor.cxx
@@ -245,7 +245,11 @@ void EventProcessor::parseVTPData(EVENT::LCGenericObject* vtp_data_lcio)
                     case 2: // HPS Cluster
                         VTPData::hpsCluster  clus;
                         clus.X        = (data      )&0x0003F;
+                        // If the first bit of the index is 1, then it is a negative number
+                        if((clus.X >> 5 & 0x1) == 0x1) clus.X = -((clus.X ^ 0x3F) + 1);
                         clus.Y        = (data >>  6)&0x0000F;
+                       // If the first bit of the index is 1, then it is a negative number
+                        if((clus.Y  >> 3 & 0x1) == 0x1) clus.Y  = -((clus.Y ^ 0xF) + 1);
                         clus.E        = (data >> 10)&0x01FFF;
                         clus.subtype  = (data >> 23)&0x0000F;
                         clus.type     = (data >> 27)&0x0000F;


### PR DESCRIPTION
Some corrections are taken:
1) In processors/src/EventProcessor.cxx, parse for VTP cluster X and Y is corrected so that negative values are correctly expressed. The range should be [-22, 23] for X, and [-5, -1] & [1, 5] for Y.
2) In processing/src/HpsEventFile.cxx, comment of the function `HpsEventFile::nextEvent()` is corrected. Before correction, the first event is skipped when reading events from tree. We should read events starting from event 0 instead of event 1.
3) In event/include/CalCluster.h, one member function `int getNHits() const { return n_hits_; } ` is added, so that # of hits for Ecal cluster is easily obtained.