### PR TITLE
make plotting all the regions easier 

### DIFF
--- a/plotUtils/compareKalGBL.py
+++ b/plotUtils/compareKalGBL.py
@@ -2,12 +2,49 @@ import ROOT as r
 import os
 import utilities as utils
 
+import argparse
+
+parser = argparse.ArgumentParser(description="The baseConfig options for compareKalGBL. ")
+
+parser.add_argument('--debug', '-D', action="count", dest="debug", help="Increase debug level.", default=0)
+
+#parser.add_option("-i", "--inFile", type="string", dest="inFilename",
+#                  help="Input filename.", metavar="inFilename", default="")
+parser.add_argument("-i", "--inFileBase", type=str, dest="inFileBase", action='store',
+                  help="input file base, use when files are in the same directory and only differ by kf/gbl.root",  default=None)
+parser.add_argument("-k", "--kalFile", type=str, dest="kalFile", action='store',
+                  help="kal file",  default=None)
+parser.add_argument("-g", "--gblFile", type=str, dest="gblFile", action='store',
+                  help="gbl file",  default=None)
+parser.add_argument("--doMC", dest="doMC", action='store_true',
+                  help="Make MC folder plots", default=False)
+parser.add_argument("--doSimp", dest="doSimp", action='store_true',
+                  help="Make Simp vtxana_kf_vtxSelection plots", default=False)
+
+options = parser.parse_args()
+ifb = options.inFileBase
+fkal = options.kalFile
+fgbl = options.gblFile
+doMC = options.doMC
+doSimp = options.doSimp
+
+print(ifb)
+
+inFileList=[]
+
+if ifb:
+    inFileList.append(ifb+"_GBL.root")
+    inFileList.append(ifb+"_KF.root")
+elif kalFile and gblFile:
+    inFileList.append(fgbl)
+    inFileList.append(fkal)
+else:
+    path = "/gpfs/slac/atlas/fs1/d/ssevova/hps/hpstr/histos"
+    inFileList.append(path+"/simp/gbl/simp_100_60_33p3_recon_ctau10mm_anaGBLVtx.root")
+    inFileList.append(path+"/simp/kftrackstight/latest/simp_100_60_33p3_recon_ctau10mm_anaKalVtx.root")
 
 utils.SetStyle()
 
-path = "/gpfs/slac/atlas/fs1/d/ssevova/hps/hpstr/histos"
-inFileList = ["simp/gbl/simp_100_60_33p3_recon_ctau10mm_anaGBLVtx.root",
-              "simp/kftrackstight/latest/simp_100_60_33p3_recon_ctau10mm_anaKalVtx.root"]
     #"tritrig/tritrig_anaVtx.root",
     #"wab/wab_anaVtx.root",
     #"simp/simp_100_60_33p3_recon_ctau10mm_anaVtx.root",
@@ -19,66 +56,108 @@ inFileList = ["simp/gbl/simp_100_60_33p3_recon_ctau10mm_anaGBLVtx.root",
 
 colors = [r.kBlack, r.kRed, r.kBlue, r.kGreen+2, r.kOrange-2]
 
-inputFiles = []
 legends     = [#"tritrig",
                #"wab",
                "gbl_simp_100_60_33p3",
                "kf_simp_100_60_33p3"]
 #               "simp_100_40_30",
 #               "simp_50_30_16p7"]
-outdir     = "KF_vs_GBL_simp_100_60_33p3_vtxPresel"
-selection  = ["vtxana_gbl_vtxSelection","vtxana_kf_vtxSelection"]
 
-if not os.path.exists(outdir):
-    os.makedirs(outdir)
+selection = ["vtxSelection"]
 
-r.gROOT.SetBatch(1)
+if doSimp:
+        selection.append("simpTight")
+        selection.append("simpTightL1L1")
 
-for ifile in inFileList:
-    inf = r.TFile(path+"/"+ifile)
-    inputFiles.append(inf)
-    pass
+if doMC:
+        mcselection=[]
+        print(selection)
+        for sel in selection:
+                mcselection.append("mc_"+sel)
+        selection.extend(mcselection)
 
-canvs = []
+if not os.path.exists("plots"):
+    os.makedirs("plots")
 
-for key in inputFiles[0].Get(selection[0]).GetListOfKeys():
-    histos = []
-    histos2D = []
-    xtitle = []
-    ytitle = []
-    name   = []
+basedir=os.getcwd()
 
-    print(key.GetName())
-    c = r.TCanvas()
-    for i_f in range(0,len(inputFiles)):
-        keyname = ''
-        if '_kf_' in selection[i_f]:
-            keyname = (key.GetName()).replace("vtxana_gbl_vtx","vtxana_kf_vtx")
-        else:
-            keyname = key.GetName()
+print("Making plots for ", selection)
 
-        if '_hh' in key.GetName():
-            histos2D.append(inputFiles[i_f].Get(selection[i_f]).Get(keyname))
-            xtitle.append(histos2D[i_f].GetXaxis().GetTitle())
-            if 'ele_z0' in key.GetName():
-                ytitle.append('trk z0 [mm]')
+algs=["gbl","kf"]
+
+for sel in selection:
+    print("plotting selection " + sel)
+    outdir     = "plots/KF_vs_GBL_simp_100_60_33p3_" + sel
+
+#selection  = ["vtxana_gbl_vtxSelection","vtxana_kf_vtxSelection"]
+    os.chdir(basedir)
+    if not os.path.exists(outdir):
+        print("Making Directory " + outdir)
+        os.makedirs(outdir)
+
+
+    r.gROOT.SetBatch(1)
+    inputFiles = []
+
+    for ifile in inFileList:
+        print("Loading file " + ifile)
+        inf = r.TFile(ifile)
+        inputFiles.append(inf)
+        pass
+
+    canvs = []
+    print("vtxana_gbl_"+sel)
+    for key in inputFiles[0].Get("vtxana_gbl_"+sel).GetListOfKeys():
+        #hack because its picking up a tree
+        if "tree" in key.GetName():
+            continue
+        print("My key " + key.GetName())
+        histos = []
+        histos2D = []
+        xtitle = []
+        ytitle = []
+        name   = []
+
+        c = r.TCanvas()
+        for i_f in range(0,len(inputFiles)):
+            #print("i_f " + str(i_f))
+            #print("Looking at file " + inputFiles[i_f].GetName())
+            keyname = ''
+            if 'KF' in inputFiles[i_f].GetName():
+                keyname = (key.GetName()).replace("vtxana_gbl","vtxana_kf")
             else:
-                ytitle.append(histos2D[i_f].GetYaxis().GetTitle())
+                keyname = key.GetName()
+            #print("My KeyName " + keyname)
+            if '_hh' in key.GetName():
+                histos2D.append(inputFiles[i_f].Get("vtxana_"+algs[i_f]+"_"+sel).Get(keyname))
+                xtitle.append(histos2D[i_f].GetXaxis().GetTitle())
+                if 'ele_z0' in key.GetName():
+                    ytitle.append('trk z0 [mm]')
+                else:
+                    ytitle.append(histos2D[i_f].GetYaxis().GetTitle())
 
-            name.append(key.GetName()+'_'+legends[i_f])
-        
-        histos.append(inputFiles[i_f].Get(selection[i_f]).Get(keyname))
+                name.append(key.GetName()+'_'+legends[i_f])
+
+            histos.append(inputFiles[i_f].Get("vtxana_"+algs[i_f]+"_"+sel).Get(keyname))
+
+            #print(inputFiles[i_f].GetName())
+            #print("vtxana_"+algs[i_f]+"_"+sel)
+            #print(keyname)
+            #print(inputFiles[i_f].Get("vtxana_"+algs[i_f]+"_"+sel).ls())
+
         #histos[i_f].SetMarkerColor(colors[i_f])
         #histos[i_f].SetLineColor(colors[i_f])
-        pass
-    canvs+=utils.Make2DPlots(name,outdir,histos2D,xtitle,ytitle)
-    canvs.append(utils.MakePlot(key.GetName(),outdir,histos,legends,".png",LogY=False,RatioType="Sequential",Normalise=False))
-    canvs.append(utils.MakePlot(key.GetName()+"_log",outdir,histos,legends,".png",LogY=True,RatioType="Sequential",Normalise=False))
-    pass
+            pass
 
-utils.makeHTML(outdir,'SIMPs KF vs GBL (vtxPresel)', selection)
-outF = r.TFile("KF_vs_GBL_simp_100_60_33p3_vtxPresel.root","RECREATE")
-outF.cd()
-for canv in canvs: 
-    if canv != None: canv.Write()
-outF.Close()
+        canvs+=utils.Make2DPlots(name,outdir,histos2D,xtitle,ytitle)
+        canvs.append(utils.MakePlot(key.GetName(),outdir,histos,legends,".png",LogY=False,RatioType="Sequential",Normalise=False))
+        canvs.append(utils.MakePlot(key.GetName()+"_log",outdir,histos,legends,".png",LogY=True,RatioType="Sequential",Normalise=False))
+        pass
+    print(outdir)
+    utils.makeHTML(outdir,'SIMPs KF vs GBL ('+sel+')'   , selection)
+    outF = r.TFile("KF_vs_GBL_simp_100_60_33p3_vtxPresel"+sel+".root","RECREATE")
+    outF.cd()
+    for canv in canvs:
+        if canv != None: canv.Write()
+    outF.Close()
+    #inf.Close()

--- a/plotUtils/utilities.py
+++ b/plotUtils/utilities.py
@@ -39,7 +39,7 @@ def getPlot(loc,fin,plot):
     histo = f.Get(plot)
     print( histo )
     histo.SetDirectory(0)
-    
+
     return histo
 
 
@@ -50,7 +50,7 @@ def getPlot(fullpath,plot):
     histo = f.Get(plot)
     print(histo)
     histo.SetDirectory(0)
-    
+
     return histo
 
 
@@ -75,17 +75,17 @@ def MakeHistoListFromSameFile(infile,path,histoNames):
         print( h_name )
         f = TFile.Open(infile)
         print( f )
-        
+
         h = f.Get(path+"/"+h_name)
         print( h )
         h.SetDirectory(0)
         histolist.append(h)
-    return histolist    
+    return histolist
 
 
 def InsertText(runNumber="",texts=[],line=0.87,xoffset=0.18,Hps=True,Colors=False):
 
-    
+
     newline = 0.06
 
     text = r.TLatex()
@@ -108,7 +108,7 @@ def InsertText(runNumber="",texts=[],line=0.87,xoffset=0.18,Hps=True,Colors=Fals
             if (Colors):
                 text.SetTextColor(colors[iText])
             text.DrawLatex(xoffset,line,texts[iText])
-            
+
     return line
 
 
@@ -116,7 +116,7 @@ def SetStyle():
     r.gROOT.SetBatch(1)
 
     hpsStyle= r.TStyle("HPS","HPS style")
-    
+
     # use plain black on white colors
     icol=0
     hpsStyle.SetFrameBorderMode(icol)
@@ -126,14 +126,14 @@ def SetStyle():
     hpsStyle.SetCanvasColor(icol)
     hpsStyle.SetStatColor(icol)
 #hpsStyle.SetFillColor(icol)
-    
+
 # set the paper & margin sizes
-    hpsStyle.SetPaperSize(20,26) 
+    hpsStyle.SetPaperSize(20,26)
     hpsStyle.SetPadTopMargin(0.05)
     hpsStyle.SetPadRightMargin(0.05)
     hpsStyle.SetPadBottomMargin(0.18)
     hpsStyle.SetPadLeftMargin(0.14)
-    
+
     # use large fonts
 #font=72
     font=42
@@ -141,7 +141,7 @@ def SetStyle():
     tzsize = 0.045
     hpsStyle.SetTextFont(font)
 
-    
+
     hpsStyle.SetTextSize(tsize)
     hpsStyle.SetLabelFont(font,"x")
     hpsStyle.SetTitleFont(font,"x")
@@ -149,7 +149,7 @@ def SetStyle():
     hpsStyle.SetTitleFont(font,"y")
     hpsStyle.SetLabelFont(font,"z")
     hpsStyle.SetTitleFont(font,"z")
-    
+
     hpsStyle.SetLabelSize(tsize,"x")
     hpsStyle.SetTitleSize(tsize,"x")
     hpsStyle.SetLabelSize(tsize,"y")
@@ -159,49 +159,49 @@ def SetStyle():
 
     hpsStyle.SetTitleOffset(0.7,"y")
     hpsStyle.SetTitleOffset(1.15,"x")
-    
-    
+
+
 #use bold lines and markers
     #hpsStyle.SetMarkerStyle(20)
     hpsStyle.SetMarkerSize(1.0)
     hpsStyle.SetHistLineWidth(3)
     hpsStyle.SetLineStyleString(2,"[12 12]") # postscript dashes
-    
+
 #get rid of X error bars and y error bar caps
 #hpsStyle.SetErrorX(0.001)
-    
+
 #do not display any of the standard histogram decorations
     hpsStyle.SetOptTitle(0)
 #hpsStyle.SetOptStat(1111)
     hpsStyle.SetOptStat(0)
 #hpsStyle.SetOptFit(1111)
     hpsStyle.SetOptFit(0)
-    
+
 # put tick marks on top and RHS of plots
-    hpsStyle.SetPadTickX(1) 
+    hpsStyle.SetPadTickX(1)
     hpsStyle.SetPadTickY(1)
-    
+
     r.gROOT.SetStyle("Plain")
 
 #gStyle.SetPadTickX(1)
 #gStyle.SetPadTickY(1)
     r.gROOT.SetStyle("HPS")
-    r.gROOT.ForceStyle() 
+    r.gROOT.ForceStyle()
     r.gStyle.SetOptTitle(0)
-    r.gStyle.SetOptStat(0) 
-    r.gStyle.SetOptFit(0) 
+    r.gStyle.SetOptStat(0)
+    r.gStyle.SetOptFit(0)
 
 
 # overwrite hps styles
     hpsStyle.SetPadLeftMargin(0.14)
-    hpsStyle.SetPadRightMargin(0.06)    
-    hpsStyle.SetPadBottomMargin(0.11)     
-    hpsStyle.SetPadTopMargin(0.05) 
+    hpsStyle.SetPadRightMargin(0.06)
+    hpsStyle.SetPadBottomMargin(0.11)
+    hpsStyle.SetPadTopMargin(0.05)
     hpsStyle.SetFrameFillColor(0)
 
     NRGBs = 5;
     NCont = 255;
-    
+
     stops = array("d",[ 0.00, 0.34, 0.61, 0.84, 1.00 ])
     red   = array("d",[ 0.00, 0.00, 0.87, 1.00, 0.51 ])
     green = array("d",[ 0.00, 0.81, 1.00, 0.20, 0.00 ])
@@ -210,14 +210,14 @@ def SetStyle():
     r.gStyle.SetNumberContours(NCont);
 
 def MakeRadFrac(name,outdir,histos,legends,oFext,xtitle="",ytitle="",ymin=0,ymax=1,noErrors=False,RebinFactor=0,runNumber="",additionalText=[],RatioType="Alternate",LogX=False,LogY=False,RatioMin=0.0,RatioMax=0.15,WriteMean=False,Normalise=False):
-    
-    
+
+
     if not os.path.exists(outdir):
         os.mkdir(outdir)
-        
+
     Xmin=0
     Xmax=1
-        
+
     can = r.TCanvas(name, name, 1200, 800)
     can.SetMargin(0,0,0,0)
     top = r.TPad("top","top",0,0.42,1,1)
@@ -226,11 +226,11 @@ def MakeRadFrac(name,outdir,histos,legends,oFext,xtitle="",ytitle="",ymin=0,ymax
         bot.SetLogx(1)
     if LogY:
         top.SetLogy(1)
-    
+
     bot = r.TPad("bot","bot",0,0,1,0.38)
 
     #----------Histogram------------#
-    
+
     top.Draw()
     top.SetBottomMargin(0)
     top.SetTopMargin(r.gStyle.GetPadTopMargin()*topScale)
@@ -240,7 +240,7 @@ def MakeRadFrac(name,outdir,histos,legends,oFext,xtitle="",ytitle="",ymin=0,ymax
     top.cd()
     plotsProperties=[]
     histoStack = r.THStack(name+"_sh","")
-    
+
     for ih in range(len(histos)):
 
         if (Normalise):
@@ -248,8 +248,8 @@ def MakeRadFrac(name,outdir,histos,legends,oFext,xtitle="",ytitle="",ymin=0,ymax
                 return None
             histos[ih].Scale(1./histos[ih].Integral())
             histos[ih].GetYaxis().SetRangeUser(0.00001,histos[ih].GetMaximum()*15000)
-            
-                    
+
+
         histos[ih].GetXaxis().SetRangeUser(0.03,0.2)
         histos[ih].SetMarkerColor(colors[ih])
         histos[ih].SetMarkerStyle(markers[ih])
@@ -257,10 +257,10 @@ def MakeRadFrac(name,outdir,histos,legends,oFext,xtitle="",ytitle="",ymin=0,ymax
         histos[ih].GetXaxis().CenterTitle()
         histos[ih].GetYaxis().CenterTitle()
         histos[ih].GetYaxis().SetTitleOffset(0.4)
-        
+
         plotsProperties.append(("#mu=%.4f"%round(histos[ih].GetMean(),4))+(" #sigma=%.4f"%round(histos[ih].GetRMS(),4)))
-        
-        
+
+
         if RebinFactor>0:
             histos[ih].Rebin(RebinFactor)
 
@@ -294,14 +294,14 @@ def MakeRadFrac(name,outdir,histos,legends,oFext,xtitle="",ytitle="",ymin=0,ymax
         leg.SetFillColor(0)
         leg.SetTextSize(0.04)
         for i_leg in range(len(legends)):
-            #print "Adding Entry",i_leg, legends[i_leg] 
-            leg.AddEntry(histos[i_leg],legends[i_leg],"lpf") 
+            #print "Adding Entry",i_leg, legends[i_leg]
+            leg.AddEntry(histos[i_leg],legends[i_leg],"lpf")
             pass
         leg.Draw()
         pass
-        
+
     #-------------Ratio---------------------#
-        
+
     bot.cd()
     numerator = histos[0].Clone("numerator")
     numerator.GetYaxis().SetTitle("f_{rad}")
@@ -339,20 +339,20 @@ def MakeRadFrac(name,outdir,histos,legends,oFext,xtitle="",ytitle="",ymin=0,ymax
     fitFunc = numerator.GetListOfFunctions().FindObject("pol5")
     fitFunc.SetLineColor(colors[3])
     numerator.DrawCopy("pe same")
-          
+
     line = r.TLine()
     line.SetLineStyle(r.kDashed)
     line.DrawLine(0.03,fitCon,0.2,fitCon)
-    
+
     can.SaveAs(outdir+"/"+name+oFext)
     return deepcopy(can)
 
 def MakePlot(name,outdir,histos,legends,oFext,xtitle="",ytitle="",ymin=0,ymax=1,noErrors=False,RebinFactor=0,runNumber="",additionalText=[],RatioType="Alternate",LogX=False,LogY=False,RatioMin=0.25,RatioMax=1.75,WriteMean=False,Normalise=False,doFit=False,drawOptions="hist",Xmin=-999,Xmax=-999):
-    
-    
+
+
     if not os.path.exists(outdir):
         os.mkdir(outdir)
-    
+
     #Make 1D plots only
     if "_hh" in name: return None
 
@@ -364,11 +364,11 @@ def MakePlot(name,outdir,histos,legends,oFext,xtitle="",ytitle="",ymin=0,ymax=1,
         bot.SetLogx(1)
     if LogY:
         top.SetLogy(1)
-    
+
     bot = r.TPad("bot","bot",0,0,1,0.38)
 
     #----------Histogram------------#
-    
+
     top.Draw()
     top.SetBottomMargin(0)
     top.SetTopMargin(r.gStyle.GetPadTopMargin()*topScale)
@@ -383,7 +383,7 @@ def MakePlot(name,outdir,histos,legends,oFext,xtitle="",ytitle="",ymin=0,ymax=1,
             Ymax = histos[ih].GetMaximum()*1.9
 
     for ih in range(len(histos)):
-        
+
         if (Normalise):
 
             if (histos[ih].Integral() == 0):
@@ -391,26 +391,26 @@ def MakePlot(name,outdir,histos,legends,oFext,xtitle="",ytitle="",ymin=0,ymax=1,
             histos[ih].Scale(1./histos[ih].Integral())
             if LogY: histos[ih].GetYaxis().SetRangeUser(0.00001,histos[ih].GetMaximum()*15000)
             else:    histos[ih].GetYaxis().SetRangeUser(0.00001,histos[ih].GetMaximum()*2.2)
-            
-        elif not Normalise: 
-            if LogY: 
+
+        elif not Normalise:
+            if LogY:
                 histos[ih].GetYaxis().SetRangeUser(0.00001,histos[ih].GetMaximum()*15000)
-            else:    
+            else:
                 histos[ih].GetYaxis().SetRangeUser(0,Ymax)
-            
+
 
         histos[ih].SetMarkerColor(colors[ih])
         histos[ih].SetMarkerStyle(markers[ih])
         histos[ih].SetLineColor(colors[ih])
         histos[ih].GetXaxis().CenterTitle()
         histos[ih].GetYaxis().CenterTitle()
-        
 
-        
+
+
         if (not doFit):
             plotsProperties.append(("#mu=%.4f"%round(histos[ih].GetMean(),4))+(" #sigma=%.4f"%round(histos[ih].GetRMS(),4)))
-        
-        
+
+
         if RebinFactor>0:
             histos[ih].Rebin(RebinFactor)
 
@@ -420,27 +420,27 @@ def MakePlot(name,outdir,histos,legends,oFext,xtitle="",ytitle="",ymin=0,ymax=1,
             fit_funcs.append(TF1("fit_func"+str(ih),"gaus",-2.5,2.5))
             print( len(fit_funcs) )
             bad_fit = histos[ih].Fit(fit_funcs[ih],"RQN")
-            
+
             mu = fit_funcs[ih].GetParameter(1)
             mu_err  = fit_funcs[ih].GetParError(1)
             sigma = fit_funcs[ih].GetParameter(2)
-            sigma_err = fit_funcs[ih].GetParError(2)    
-            
+            sigma_err = fit_funcs[ih].GetParError(2)
+
             plotsProperties.append((" #mu=%.3f"%round(mu,3))+("+/- %.3f"%round(mu_err,3))
                                    +(" #sigma=%.3f"%round(sigma,3)) +("+/- %.3f"%round(sigma_err,3) ))
-            
+
             fit_funcs[ih].SetLineColor(histos[ih].GetLineColor())
 
 
         if ih==0:
-                
+
             if (Xmin !=-999 and Xmax !=-999):
                 histos[ih].GetXaxis().SetRangeUser(Xmin,Xmax)
             if noErrors:
                 #histos[ih].GetXaxis().SetTextSize(0.045)
                 #histos[ih].GetYaxis().SetTextSize(0.045)
                 histos[ih].Draw("e")
-                
+
             else:
                 histos[ih].Draw("e")
             if xtitle:
@@ -453,10 +453,10 @@ def MakePlot(name,outdir,histos,legends,oFext,xtitle="",ytitle="",ymin=0,ymax=1,
                 histos[ih].Draw("same "+drawOptions)
             else:
                 histos[ih].Draw("same e "+drawOptions)
-        
+
         if (doFit):
             fit_funcs[ih].Draw("same")
-            
+
 
 
     linevalue = InsertText(runNumber,additionalText,0.8,xoffset=0.75)
@@ -477,14 +477,14 @@ def MakePlot(name,outdir,histos,legends,oFext,xtitle="",ytitle="",ymin=0,ymax=1,
         leg.SetFillColor(0)
         leg.SetTextSize(0.04)
         for i_leg in range(len(legends)):
-            #print "Adding Entry",i_leg, legends[i_leg] 
-            leg.AddEntry(histos[i_leg],legends[i_leg],"lpf") 
+            #print "Adding Entry",i_leg, legends[i_leg]
+            leg.AddEntry(histos[i_leg],legends[i_leg],"lpf")
             pass
         leg.Draw()
         pass
-        
+
     #-------------Ratio---------------------#
-        
+
     bot.cd()
     reference = histos[0].Clone("reference")
     reference.GetXaxis().SetLabelSize(0.1)
@@ -499,34 +499,34 @@ def MakePlot(name,outdir,histos,legends,oFext,xtitle="",ytitle="",ymin=0,ymax=1,
     reference.Draw("axis")
 
     if (RatioType=="Sequential"):
-        
-        
+
+
         for ih in range(1,len(histos)):
             #ForRatio=None
             #if type(histos[ih]) is TProfile:
             #    ForRatio = histos[ih].ProjectionX("ForRatio"+str(ih)+histos[ih].GetName())
             #else:
             ForRatio = histos[ih].Clone("ForRatio"+str(ih)+histos[ih].GetName())
-            
+
             ForRatio.SetMaximum(100.)
             ForRatio.Divide(reference)
             ForRatio.DrawCopy("pe same")
 
 
     elif (RatioType=="Alternate"):
-        
+
         print( "in alternate ratio" )
         for ih in range(1,len(histos),2):
-            
+
             numerator=histos[ih].Clone("numerator")
             #if isinstance(histos[ih],TProfile):
-                
+
             #    numerator=histos[ih].ProjectionX("numerator")
-                
+
             #else:
-            
-                
-            
+
+
+
             numerator.SetMaximum(100.)
             numerator.Divide(histos[ih-1])
             numerator.DrawCopy("pe same")
@@ -534,27 +534,27 @@ def MakePlot(name,outdir,histos,legends,oFext,xtitle="",ytitle="",ymin=0,ymax=1,
 
     elif (RatioType=="Alternate2"):
           print( "in Alternate (h1 - h2) / h2" )
-          
+
 
           numerator=histos[ih].Clone("numerator")
           numerator.Add(histos[ih-1],-1)
           numerator.SetMaximum(100.)
           numerator.Divide(histos[ih-1])
-          
+
           numerator.DrawCopy("hist p same")
-          
-          
-          
+
+
+
     line = r.TLine()
     line.SetLineStyle(r.kDashed)
     if (Xmin!=-999 and Xmax!=-999):
         line.DrawLine(Xmin,1,Xmax,1)
     else:
         line.DrawLine(reference.GetXaxis().GetXmin(),1,reference.GetXaxis().GetXmax(),1)
-    
+
     can.SaveAs(outdir+"/"+name+oFext)
     return deepcopy(can)
-    
+
 
 def DivideHistos(h1,h2):
     for ibin in range(1,h1.GetNbinsX()+1):
@@ -566,12 +566,12 @@ def DivideHistos(h1,h2):
 
 
 def Make1Dplots(name,outdir,histos,colors,markers,legends,oFext,xtitle="",ytitle="",ymin=0,ymax=1,noErrors=False,RebinFactor=0,runNumber="",additionalText=[],LogY=False,WriteMean=False,multiLeg=False):
-        
+
 
     if not os.path.exists(outdir):
         os.mkdir(outdir)
 
-                
+
     can = r.TCanvas(name,name,1500,1000)
     if LogY:
         can.SetLogy(1)
@@ -579,12 +579,12 @@ def Make1Dplots(name,outdir,histos,colors,markers,legends,oFext,xtitle="",ytitle
     means   = []
     meansErr = []
 
-    
+
     for ih in range(len(histos)):
-        
+
         means.append(histos[ih].GetMean(2))
         meansErr.append(histos[ih].GetMeanError(2))
-        
+
         histos[ih].SetMarkerColor(colors[ih])
         histos[ih].SetMarkerStyle(markers[ih])
         histos[ih].SetLineColor(colors[ih])
@@ -613,7 +613,7 @@ def Make1Dplots(name,outdir,histos,colors,markers,legends,oFext,xtitle="",ytitle
                 histos[ih].Draw("same hist p")
             else:
                 histos[ih].Draw("same")
-                        
+
     InsertText(runNumber,additionalText,0.8,xoffset=0.7)
 
     if len(legends)>0:
@@ -631,31 +631,31 @@ def Make1Dplots(name,outdir,histos,colors,markers,legends,oFext,xtitle="",ytitle
             leg2.SetFillColor(0)
             entry=leg2.AddEntry("Todo","To do","p")
             entry.SetMarkerStyle(kOpenSquare)
-            
+
             entry2=leg2.AddEntry("Todo","Todo","p")
             entry2.SetMarkerStyle(kOpenCircle)
             leg2.Draw()
-            
 
-            
+
+
             minX=0.87
             maxX=minX+0.12
-            
+
 
         leg=r.TLegend(minX,upperY,maxX,lowerY)
         leg.SetBorderSize(0)
         leg.SetFillColor(0)
         leg.SetTextSize(0.031)
-        
 
-                
+
+
         for i_leg in range(len(legends)):
-            
+
             if not WriteMean:
                 print( "Adding Entry {} {}".format(i_leg, legends[i_leg]) )
             else:
                 print( "Adding Entry {} {} #epsilon: {} ".format(i_leg, legends[i_leg], str(round(means[i_leg],2))) )
-            
+
 
             #leg.AddEntry(histos[i_leg],"#splitline{"+legends[i_leg] + "}{Average=" + str(round(means[i_leg]*100.,3))+"#pm"+str(round(meansErr[i_leg]*100,3))+"%}" ,"lpf")
             #leg.AddEntry(histos[i_leg],legends[i_leg] + " Average=" + str(round(means[i_leg]*100.,3))+"#pm"+str(round(meansErr[i_leg]*100,3))+"%" ,"lpf")
@@ -663,17 +663,17 @@ def Make1Dplots(name,outdir,histos,colors,markers,legends,oFext,xtitle="",ytitle
                 leg.AddEntry(histos[i_leg],legends[i_leg] + " Avg=" + str(round(means[i_leg]*100.,3))+"#pm"+str(round(meansErr[i_leg]*100,3))+"%" ,"lpf")
             else:
                 leg.AddEntry(histos[i_leg],"#splitline{"+legends[i_leg] + "}{Avg=" + str(round(means[i_leg]*100.,3))+"#pm"+str(round(meansErr[i_leg]*100,3))+"%}" ,"lpf")
-            
+
             leg.Draw()
 
     #BuildLegend(legends,can,histos,0.55,0.9,0.8,0.75)
-    
-        
+
+
     can.SetBottomMargin(0.18)
     can.SetLeftMargin(0.15)
 
     can.SaveAs(outdir+"/"+name+oFext)
-    
+
 
 
 def Make2DRatio(name,outdir,histo1,histo2,xtitle="",ytitle="",ztitle="",runNumber="",legends=[]):
@@ -683,19 +683,19 @@ def Make2DRatio(name,outdir,histo1,histo2,xtitle="",ytitle="",ztitle="",runNumbe
 
     ratio = histo1.Clone()
     ratio.Divide(histo2)
-    
+
     can = r.TCanvas()
     can.SetRightMargin(0.2)
-    
+
     ratio.GetZaxis().SetRangeUser(0.9,1.1)
     ratio.GetXaxis().SetTitle(xtitle)
     ratio.GetYaxis().SetTitle(ytitle)
     ratio.GetZaxis().SetTitle(ztitle)
     ratio.Draw("colz text")
-    
+
     can.SaveAs(outdir+"/"+name+oFext)
-    
-    
+
+
 
 def Make2DPlots(name,outdir,histolist,xtitle,ytitle,ztitle="",text="",zmin="",zmax=""):
     oFext=".pdf"
@@ -705,7 +705,7 @@ def Make2DPlots(name,outdir,histolist,xtitle,ytitle,ztitle="",text="",zmin="",zm
     for ih in range(0,len(histolist)):
         can = r.TCanvas()
         can.SetRightMargin(0.2)
-        
+
         #histolist[ih].GetZaxis().SetRangeUser(zmin,zmax)
         histolist[ih].GetXaxis().SetTitle(xtitle[ih])
         histolist[ih].GetXaxis().SetTitleSize(
@@ -714,7 +714,7 @@ def Make2DPlots(name,outdir,histolist,xtitle,ytitle,ztitle="",text="",zmin="",zm
             histolist[ih].GetXaxis().GetLabelSize()*0.75)
         histolist[ih].GetXaxis().SetTitleOffset(
             histolist[ih].GetXaxis().GetTitleOffset()*0.8)
-        
+
         histolist[ih].GetYaxis().SetTitleSize(
             histolist[ih].GetYaxis().GetTitleSize()*0.7)
         histolist[ih].GetYaxis().SetLabelSize(
@@ -722,37 +722,37 @@ def Make2DPlots(name,outdir,histolist,xtitle,ytitle,ztitle="",text="",zmin="",zm
         histolist[ih].GetYaxis().SetTitleOffset(
             histolist[ih].GetYaxis().GetTitleOffset()*1.7)
         histolist[ih].GetYaxis().SetTitle(ytitle[ih])
-        
+
         histolist[ih].Draw("colz")
-        
-        
+
+
         InsertText(text,"")
-        
+
         #print "saving..."
         #if (len(legends) == len(histolist)):
         can.SaveAs(outdir+"/"+name[ih]+oFext)
         canvs.append(can)
     return deepcopy(canvs)
-        #else:            
+        #else:
         #    print "ERROR: Not enough names for all the histos"
-            
+
 
 def Profile2DPlot(name,outdir,histolist,axis="X",xtitle="",ytitle="",ztitle="",runNumber="",legends=[],zmin="",zmax=""):
     oFext=".pdf"
     if not os.path.exists(outdir):
         os.mkdir(outdir)
-        
+
     p = None
-    
+
     if (axis == "X"):
         p = ProjectionX()
-    
+
 def makeHTML(outDir,title,selection):
     os.chdir(outDir)
     plots = glob.glob('*.png') + glob.glob('*.pdf')
     plots.sort()
-
-    f = open(outDir+'.html',"w+")
+    outfilebase = os.path.split(outDir)[1]
+    f = open(outfilebase+'.html',"w+")
     f.write("<!DOCTYPE html\n")
     f.write(" PUBLIC \"-//W3C//DTD HTML 3.2//EN\">\n")
     f.write("<html>\n")
@@ -763,15 +763,15 @@ def makeHTML(outDir,title,selection):
         pname = ""
         if selection[0] in plots[i]:
             pname = plots[i].replace(selection[0]+'_','')
-            
+
         offset = 1
         if i==0 or i%2==0: f.write("<tr>\n")
         f.write("<td width=\"10%\"><a target=\"_blank\" href=\"" + plots[i] + "\"><img src=\"" + plots[i] + "\" alt=\"" + plots[i] + "\" title=\"" + pname + "\" width=\"85%\" ></a></td>\n")
-        if i==offset: 
+        if i==offset:
             f.write("</tr>\n")
-        elif (i>offset and (i-offset)%2==0) or i==len(plots): 
+        elif (i>offset and (i-offset)%2==0) or i==len(plots):
             f.write("</tr>\n")
-            
+
     f.write("</table>\n")
     f.write("</body>\n")
     f.write("</html>")


### PR DESCRIPTION
This makes the compareKalGBL.py script run over all the regions.  Right now it just runs over the SIMP regions if the doSIMP flag is set to true, but vertex analysis or whatever should add a flag.  I don't know where all the whitespace difference came from in utilities.py.  