### PR TITLE
Correction to order of toy generator fit function.

### DIFF
--- a/analysis/src/BumpHunter.cxx
+++ b/analysis/src/BumpHunter.cxx
@@ -184,10 +184,10 @@ HpsFitResult* BumpHunter::performSearch(TH1* histogram, double mass_hypothesis, 
         
         // Define the toy generator fit model.
         if(isChebyshev) {
-            ChebyshevFitFunction bkg_toy_func(mass_hypothesis, window_end_ - window_start_, bin_width_, bkg_order_model, FitFunction::SignalFitModel::NONE, isExp);
+            ChebyshevFitFunction bkg_toy_func(mass_hypothesis, window_end_ - window_start_, bin_width_, toy_order_model, FitFunction::SignalFitModel::NONE, isExp);
             bkg_toys = new TF1("bkg_toys", bkg_toy_func, -1, 1, toy_poly_order_ + 1);
         } else {
-            LegendreFitFunction bkg_toy_func(mass_hypothesis, window_end_ - window_start_, bin_width_, bkg_order_model, FitFunction::SignalFitModel::NONE, isExp);
+            LegendreFitFunction bkg_toy_func(mass_hypothesis, window_end_ - window_start_, bin_width_, toy_order_model, FitFunction::SignalFitModel::NONE, isExp);
             bkg_toys = new TF1("bkg_toys", bkg_toy_func, -1, 1, toy_poly_order_ + 1);
         }
         bkg_toys->SetParameter(0, initNorm);


### PR DESCRIPTION
In BumpHunter class, FitFunction is corrected such that it is
initialised with 'toy_order_model' rather than
'bkg_order_model'.
(Effect of previous code was that toy generator and background fit are
of same order and '-P' parameter is ignored).