### PR TITLE
Bug Fix. Super Simple

### DIFF
--- a/processors/src/StdhepMCParticleProcessor.cxx
+++ b/processors/src/StdhepMCParticleProcessor.cxx
@@ -56,6 +56,13 @@ bool StdhepMCParticleProcessor::process() {
     try {
      
         while( maxEvent_ < 0  || count < maxEvent_ ){
+
+           if (mc_particles_.size() > 0){
+                for (std::vector<MCParticle*>::iterator it = mc_particles_.begin(); it != mc_particles_.end(); ++it){
+                    delete *it;
+                }
+                mc_particles_.clear();
+            }
              
             std::auto_ptr<IMPL::LCEventImpl> evt( new IMPL::LCEventImpl() ) ;
             evt->setRunNumber(0) ;


### PR DESCRIPTION
Added new TrackerHit2DProcessor to get KalmanFullTrack track hit truth information.

KalmanFullTrack TrackerHits are made from 'StripClusterer_SiTrackerHitStrip1D' hits. 
We loop over all 'StripClusterer_SiTrackerHitStrip1D' hits in an event and get the SvtRawTrackerHits for each 1D hit. Using the SVTTrueHitRelations we find the SimTrackerHit corresponding to each SvtRawTrackerHit. From the SimTrackerHit we can get the MCParticle that makes the hit. 
We create a HPSTR TrackerHit for each 'StripClusterer_SiTrackerHitStrip1D', and add all of the MCParticles found on the 1D hit to that TrackerHit. This TrackerHit collection is saved as a ROOT tuple. 

To truth match KalmanFullTrack hits on track to MCParticles, you loop over the hits on a KalmanFullTrack (which are 'StripClusterer_SiTrackerHitStrip1D' hits), and then cross reference those hit IDs with the ROOT TrackerHit collection created in the TrackerHit2DProcessor. 
