### PR TITLE
KF Track Hit Truth Tupilization added

### DIFF
--- a/processors/config/anaKalSimpTuple_cfg.py
+++ b/processors/config/anaKalSimpTuple_cfg.py
@@ -3,11 +3,9 @@ import sys
 import os
 import baseConfig as base
 
-
 base.parser.add_argument("-w", "--tracking", type=str, dest="tracking",
                   help="Which tracking to use to make plots", metavar="tracking", default="KF")
 options = base.parser.parse_args()
-
 
 # Use the input file to set the output file name
 infile = options.inFilename
@@ -42,10 +40,11 @@ recoana_kf.parameters["trkColl"] = "KalmanFullTracks"
 recoana_kf.parameters["tsColl"] = "TSData"
 recoana_kf.parameters["vtxColl"] = "UnconstrainedV0Vertices_KF"
 recoana_kf.parameters["mcColl"]  = "MCParticle"
-recoana_kf.parameters["hitColl"] = "SiClustersOnTrack"
-recoana_kf.parameters["vtxSelectionjson"] = os.environ['HPSTR_BASE']+'/analysis/selections/vertexSelection_8hit.json'
-recoana_kf.parameters["histoCfg"] = os.environ['HPSTR_BASE']+"/analysis/plotconfigs/tracking/simpAnalysis_2016.json"
+recoana_kf.parameters["hitColl"] = "SiClusters"
+recoana_kf.parameters["vtxSelectionjson"] = os.environ['HPSTR_BASE']+'/analysis/selections/vertexSelection_2019.json'
+recoana_kf.parameters["histoCfg"] = os.environ['HPSTR_BASE']+"/analysis/plotconfigs/tracking/vtxAnalysis_2019.json"
 recoana_kf.parameters["mcHistoCfg"] = os.environ['HPSTR_BASE']+'/analysis/plotconfigs/mc/basicMC.json'
+#####
 recoana_kf.parameters["beamE"] = base.beamE[str(options.year)]
 recoana_kf.parameters["isData"] = options.isData
 recoana_kf.parameters["analysis"] = options.analysis
@@ -62,15 +61,12 @@ elif (options.isData==0):
 else:
     print("Specify which type of ntuple you are running on: -t 1 [for Data] / -t 0 [for MC]")
 
-
 recoana_kf.parameters["CalTimeOffset"]=CalTimeOffset
 #Region definitions
 
 RegionPath=os.environ['HPSTR_BASE']+"/analysis/selections/"
-recoana_kf.parameters["regionDefinitions"] = [RegionPath+'simpTight.json',
-                                              RegionPath+'simpTightL1L1.json']
-                                              #RegionPath+'simpTightL1L1NoSharedL0.json']
-
+recoana_kf.parameters["regionDefinitions"] = [RegionPath+'Tight_2019.json',
+                                              RegionPath+'radMatchTight_2019.json']
 #RecoHitAna
 recoana_gbl.parameters = recoana_kf.parameters.copy()
 recoana_gbl.parameters["anaName"] = "vtxana_gbl"
@@ -78,7 +74,6 @@ recoana_gbl.parameters["vtxColl"] = "UnconstrainedV0Vertices"
 recoana_gbl.parameters["tsColl"]   = "TSData"
 recoana_gbl.parameters["hitColl"] = "RotatedHelicalOnTrackHits"
 recoana_gbl.parameters["trkColl"] = "GBLTracks"
-
 
 #MCParticleAna
 mcana.parameters["debug"] = 0
@@ -101,6 +96,9 @@ if (options.tracking == "KF"):
 elif (options.tracking == "GBL"):
     print("Run GBL analysis")
     p.sequence = [recoana_gbl]#,mcana]
+elif (options.tracking == "BOTH"):
+    print("Run GBL AND KF analysis")
+    p.sequence = [recoana_gbl, recoana_kf]#,mcana]
 else :
     print ("ERROR::Need to specify which tracks KF or GBL")
     exit(1)

--- a/processors/config/kalSimpTuple_cfg.py
+++ b/processors/config/kalSimpTuple_cfg.py
@@ -10,6 +10,8 @@ base.parser.add_argument("-s", "--truthHits", type=int, dest="truthHits",
         help="Get svt truth hits: 1=yes", metavar="truthHits", default=1)
 base.parser.add_argument("-r", "--rawHits", type=int, dest="rawHits",
         help="Keep raw svt hits: 1=yes", metavar="rawHits", default=-1)
+base.parser.add_argument("-c", "--constrVtx", type=int, dest="constrVtx",
+        help="Add constrained vertices 1=yes", metavar="constrVtx", default=0)
 
 options = base.parser.parse_args()
 
@@ -133,6 +135,13 @@ vtx.parameters["partCollRoot"]   = 'ParticlesOnVertices_KF'
 vtx.parameters["kinkRelCollLcio"] = ''
 vtx.parameters["trkRelCollLcio"] = 'KFTrackDataRelations'
 
+cvtx.parameters["debug"] = 0
+cvtx.parameters["vtxCollLcio"]     = 'TargetConstrainedV0Vertices_KF'
+cvtx.parameters["vtxCollRoot"]     = 'TargetConstrainedV0Vertices_KF'
+cvtx.parameters["partCollRoot"]    = 'ParticlesOnVertices_KF'
+cvtx.parameters["kinkRelCollLcio"] = ''
+cvtx.parameters["trkRelCollLcio"]  = 'KFTrackDataRelations'
+
 vtxgbl.parameters["debug"] = 0
 vtxgbl.parameters["vtxCollLcio"]     = 'UnconstrainedV0Vertices'
 vtxgbl.parameters["vtxCollRoot"]     = 'UnconstrainedV0Vertices'
@@ -157,17 +166,24 @@ if(options.tracking == "KF"):
     #Get KF svt truth hits
     if(options.truthHits > 0):
         sequence.append(svthits)
+    if(options.constrVtx > 0):
+        sequence.append(cvtx)
 elif(options.tracking == "GBL"):
     sequence = [header, vtxgbl, ecal, trackgbl]                          
     #Get GBL svt truth hits
     if(options.truthHits > 0):
         sequence.append(svthitsgbl)
+    if(options.constrVtx > 0):
+        sequence.append(cvtxgbl)
 elif(options.tracking == "BOTH"):
     sequence = [header, vtxgbl, ecal, trackgbl, vtx, ecal, track]                          
     #Get KF and GBL svt truth hits
     if(options.truthHits > 0):
         sequence.append(svthits)
         sequence.append(svthitsgbl)
+    if(options.constrVtx > 0):
+        sequence.append(cvtx)
+        sequence.append(cvtxgbl)
 else:
     print("ERROR::Need to specify which tracks KF, GBL, or BOTH")
 

--- a/processors/config/kalSimpTuple_cfg.py
+++ b/processors/config/kalSimpTuple_cfg.py
@@ -4,6 +4,13 @@ import sys
 import baseConfig as base
 from baseConfig import bfield
 
+base.parser.add_argument("-w", "--tracking", type=str, dest="tracking",
+    help="Which tracking to use to make plots", metavar="tracking", default="KF")
+base.parser.add_argument("-s", "--truthHits", type=int, dest="truthHits",
+        help="Get svt truth hits: 1=yes", metavar="truthHits", default=1)
+base.parser.add_argument("-r", "--rawHits", type=int, dest="rawHits",
+        help="Keep raw svt hits: 1=yes", metavar="rawHits", default=-1)
+
 options = base.parser.parse_args()
 
 # Use the input file to set the output file name
@@ -28,7 +35,8 @@ header  = HpstrConf.Processor('header', 'EventProcessor')
 track   = HpstrConf.Processor('track', 'TrackingProcessor')
 trackgbl = HpstrConf.Processor('trackgbl', 'TrackingProcessor')
 trackrefitgbl = HpstrConf.Processor('trackrefitgbl', 'TrackingProcessor')
-svthits = HpstrConf.Processor('svthits', 'Tracker3DHitProcessor')
+svthits = HpstrConf.Processor('svthits', 'Tracker2DHitProcessor')  
+svthitsgbl = HpstrConf.Processor('svthits', 'Tracker3DHitProcessor') 
 rawsvt  = HpstrConf.Processor('rawsvt', 'SvtRawDataProcessor')
 ecal    = HpstrConf.Processor('ecal', 'ECalDataProcessor')
 vtx     = HpstrConf.Processor('vtx', 'VertexProcessor')
@@ -55,11 +63,16 @@ rawsvt.parameters["hitCollLcio"]    = 'SVTRawTrackerHits'
 rawsvt.parameters["hitfitCollLcio"] = 'SVTFittedRawTrackerHits'
 rawsvt.parameters["hitCollRoot"]    = 'SVTRawTrackerHits'
 
-#Tracker3DHits
+#Tracker2DHits
 svthits.parameters["debug"] = 0
-svthits.parameters["hitCollLcio"]    = 'RotatedHelicalTrackHits'
-svthits.parameters["hitCollRoot"]    = 'RotatedHelicalTrackHits'
+svthits.parameters["hitCollLcio"]    = 'StripClusterer_SiTrackerHitStrip1D' 
+svthits.parameters["hitCollRoot"]    = 'SiClusters' 
+svthits.parameters["mcPartRelLcio"]    = 'SVTTrueHitRelations'
 
+#Tracker3DHits
+svthitsgbl.parameters["hitCollLcio"]    = 'RotatedHelicalTrackHits' 
+svthitsgbl.parameters["hitCollRoot"]    = 'RotatedHelicalTrackHits' 
+svthitsgbl.parameters["mcPartRelLcio"]    = 'RotatedHelicalTrackMCRelations'
 
 #Tracking
 track.parameters["debug"] = 0
@@ -120,14 +133,12 @@ vtx.parameters["partCollRoot"]   = 'ParticlesOnVertices_KF'
 vtx.parameters["kinkRelCollLcio"] = ''
 vtx.parameters["trkRelCollLcio"] = 'KFTrackDataRelations'
 
-
 vtxgbl.parameters["debug"] = 0
 vtxgbl.parameters["vtxCollLcio"]     = 'UnconstrainedV0Vertices'
 vtxgbl.parameters["vtxCollRoot"]     = 'UnconstrainedV0Vertices'
 vtxgbl.parameters["partCollRoot"]    = 'ParticlesOnVertices'
 vtxgbl.parameters["kinkRelCollLcio"] = 'GBLKinkDataRelations'
 vtxgbl.parameters["trkRelCollLcio"]  = 'TrackDataRelations'
-
 
 cvtxgbl.parameters["debug"] = 0
 cvtxgbl.parameters["vtxCollLcio"]     = 'TargetConstrainedV0Vertices'
@@ -136,26 +147,43 @@ cvtxgbl.parameters["partCollRoot"]    = 'ParticlesOnVertices'
 cvtxgbl.parameters["kinkRelCollLcio"] = 'GBLKinkDataRelations'
 cvtxgbl.parameters["trkRelCollLcio"]  = 'TrackDataRelations'
 
-
 #MCParticle
 mcpart.parameters["debug"] = 0
 mcpart.parameters["mcPartCollLcio"] = 'MCParticle'
 mcpart.parameters["mcPartCollRoot"] = 'MCParticle'
 
-# Sequence which the processors will run.
-if (not options.isData):
-    p.sequence = [header, vtx, vtxgbl, cvtxgbl, ecal, track, trackgbl, mcpart]
+if(options.tracking == "KF"):
+    sequence = [header, vtx, ecal, track]                          
+    #Get KF svt truth hits
+    if(options.truthHits > 0):
+        sequence.append(svthits)
+elif(options.tracking == "GBL"):
+    sequence = [header, vtxgbl, ecal, trackgbl]                          
+    #Get GBL svt truth hits
+    if(options.truthHits > 0):
+        sequence.append(svthitsgbl)
+elif(options.tracking == "BOTH"):
+    sequence = [header, vtxgbl, ecal, trackgbl, vtx, ecal, track]                          
+    #Get KF and GBL svt truth hits
+    if(options.truthHits > 0):
+        sequence.append(svthits)
+        sequence.append(svthitsgbl)
 else:
-    p.sequence = [header, vtx, ecal, track]
-    #p.sequence = [header, vtx, vtxgbl, cvtxgbl, ecal, track, trackgbl]
+    print("ERROR::Need to specify which tracks KF, GBL, or BOTH")
+
+#Keep svt raw hits
+if(options.rawHits > 0):
+    sequence.append(rawsvt)
+#If MC, get MCParticles
+if(not options.isData):
+    sequence.append(mcpart)
+
+p.sequence = sequence
 
 if (options.nevents > -1 ):
     p.max_events = options.nevents
 
-
 p.input_files = lcio_file
 p.output_files = [root_file]
-
-
 
 p.printProcess()

--- a/processors/include/Tracker2DHitProcessor.h
+++ b/processors/include/Tracker2DHitProcessor.h
@@ -1,0 +1,92 @@
+/**
+ *
+ */
+
+#ifndef __TRACKER2DHIT_PROCESSOR_H__
+#define __TRACKER2DHIT_PROCESSOR_H__
+
+//-----------------//
+//   C++  StdLib   //
+//-----------------//
+#include <iostream>
+#include <string>
+#include <vector>
+
+//----------//
+//   LCIO   //
+//----------//
+#include <EVENT/LCCollection.h>
+#include <EVENT/TrackerHit.h>
+#include <IMPL/LCGenericObjectImpl.h>
+#include <IMPL/TrackerHitImpl.h>
+#include <IMPL/MCParticleImpl.h>
+#include <IMPL/SimTrackerHitImpl.h>
+#include <UTIL/LCRelationNavigator.h>
+
+//-----------//
+//   hpstr   //
+//-----------//
+#include "Collections.h"
+#include "Processor.h"
+#include "Track.h"
+#include "TrackerHit.h"
+#include "Event.h"
+
+// Forward declarations
+class TTree; 
+
+class Tracker2DHitProcessor : public Processor { 
+
+    public: 
+
+        /**
+         * Class constructor. 
+         *
+         * @param name Name for this instance of the class.
+         * @param process The Process class associated with Processor, provided
+         *                by the processing framework.
+         */
+        Tracker2DHitProcessor(const std::string& name, Process& process); 
+
+        /** Destructor */
+        ~Tracker2DHitProcessor(); 
+
+        /**
+         * Callback for the Processor to configure itself from the given set of parameters.
+         * @param parameters ParameterSet for configuration.
+         */
+        virtual void configure(const ParameterSet& parameters);
+
+        /**
+         * Callback for the Processor to take any necessary
+         * action when the processing of events starts.
+         */
+        virtual void initialize(TTree* tree);
+
+        /**
+         * Process the event and put new data products into it.
+         * @param event The Event to process.
+         */
+        virtual bool process(IEvent* ievent);
+
+        /**
+         * Callback for the Processor to take any necessary
+         * action when the processing of events finishes.
+         */
+        virtual void finalize();
+
+    private: 
+
+        /** Container to hold all TrackerHit objects. */
+        std::vector<TrackerHit*> hits_; 
+        std::string hitCollLcio_{"RotatedHelicalTrackHits"};
+        std::string hitCollRoot_{"RotatedHelicalTrackHits"};
+
+        std::string mcPartRelLcio_{"RotatedHelicalTrackMCRelations"};
+
+        //Debug Level
+        int debug_{0};
+
+}; // Tracker2DHitProcessor
+
+#endif // __TRACKER2DHIT_PROCESSOR_H__

--- a/processors/src/Tracker2DHitProcessor.cxx
+++ b/processors/src/Tracker2DHitProcessor.cxx
@@ -1,0 +1,123 @@
+#include "Tracker2DHitProcessor.h" 
+#include "utilities.h"
+
+Tracker2DHitProcessor::Tracker2DHitProcessor(const std::string& name, Process& process)
+    : Processor(name, process) { 
+}
+
+Tracker2DHitProcessor::~Tracker2DHitProcessor() { 
+}
+
+void Tracker2DHitProcessor::configure(const ParameterSet& parameters) {
+
+    std::cout << "Configuring Tracker2DHitProcessor" << std::endl;
+    try
+    {
+        debug_          = parameters.getInteger("debug", debug_);
+        hitCollLcio_    = parameters.getString("hitCollLcio", hitCollLcio_);
+        hitCollRoot_    = parameters.getString("hitCollRoot", hitCollRoot_);
+        mcPartRelLcio_ = parameters.getString("mcPartRelLcio", mcPartRelLcio_);
+    }
+    catch (std::runtime_error& error)
+    {
+        std::cout << error.what() << std::endl;
+    }
+}
+
+void Tracker2DHitProcessor::initialize(TTree* tree) {
+    // Add branches to tree
+    tree->Branch(hitCollRoot_.c_str(), &hits_);
+}
+
+bool Tracker2DHitProcessor::process(IEvent* ievent) {
+
+    for(int i = 0; i < hits_.size(); i++) delete hits_.at(i);
+    hits_.clear();
+
+    Event* event = static_cast<Event*> (ievent);
+    UTIL::LCRelationNavigator* mcPartRel_nav;
+
+    // Get the collection of 2D hits from the LCIO event. If no such collection 
+    // exist, a DataNotAvailableException is thrown
+    EVENT::LCCollection* tracker_hits{nullptr};
+    try
+    {
+        tracker_hits = event->getLCCollection(hitCollLcio_.c_str()); 
+    }
+    catch (EVENT::DataNotAvailableException e) 
+    {
+        std::cout << e.what() << std::endl;
+    }
+
+    //Check to see if MC Particles are in the file
+    auto evColls = event->getLCEvent()->getCollectionNames();
+    auto it = std::find (evColls->begin(), evColls->end(), mcPartRelLcio_.c_str());
+    bool hasMCParts = true;
+    EVENT::LCCollection* mcPartRel;
+    if(it == evColls->end()) hasMCParts = false;
+    if(hasMCParts)
+    {
+        mcPartRel = event->getLCCollection(mcPartRelLcio_.c_str());
+        // Heap an LCRelation navigator which will allow faster access 
+        mcPartRel_nav = new UTIL::LCRelationNavigator(mcPartRel);
+    }
+
+    // Create a map from an LCIO TrackerHit to a SvtHit. This will be used when
+    // assigning references to a track
+    // TODO: Use an unordered map for faster access
+    std::map<EVENT::TrackerHit*, TrackerHit*> hit_map;
+
+    // Loop over all of the 2D hits in the LCIO event and add them to the 
+    // HPS event
+    for (int ihit = 0; ihit < tracker_hits->getNumberOfElements(); ++ihit) { 
+
+        // Get a 2D hit from the list of hits
+        IMPL::TrackerHitImpl* lc_tracker_hit = static_cast<IMPL::TrackerHitImpl*>(tracker_hits->getElementAt(ihit));
+
+        if(debug_ > 0)
+            std::cout << "tracker hit lcio id: " << lc_tracker_hit->id() << std::endl;
+
+        // Build a TrackerHit
+        TrackerHit* tracker_hit = utils::buildTrackerHit(lc_tracker_hit);
+
+        if(hasMCParts)
+        {
+            //Get the SvtRawTrackerHits that make up the 2D hit
+            EVENT::LCObjectVec rawHits = lc_tracker_hit->getRawHits(); 
+            for(int irawhit = 0; irawhit < rawHits.size(); ++irawhit){
+                IMPL::TrackerHitImpl* rawhit = static_cast<IMPL::TrackerHitImpl*>(rawHits.at(irawhit));
+                if(debug_ > 0)
+                    std::cout << "rawhit on track has lcio id: " << rawhit->id() << std::endl;
+
+                // Get the list of fit params associated with the raw tracker hit
+                EVENT::LCObjectVec lc_simtrackerhits = mcPartRel_nav->getRelatedToObjects(rawhit);
+
+                //Loop over SimTrackerHits to get MCParticles
+                for(int isimhit = 0; isimhit < lc_simtrackerhits.size(); isimhit++){
+                    IMPL::SimTrackerHitImpl* lc_simhit = static_cast<IMPL::SimTrackerHitImpl*>(lc_simtrackerhits.at(isimhit));
+                    IMPL::MCParticleImpl* lc_mcp = static_cast<IMPL::MCParticleImpl*>(lc_simhit->getMCParticle());
+                    tracker_hit->addMCPartID(lc_mcp->id());
+                    if(debug_ > 0) {
+                        std::cout << "simtrackerhit lcio id: " << lc_simhit->id() << std::endl;
+                        std::cout << "mcp lcio id: " << lc_mcp->id() << std::endl;
+                    }
+                }
+            }
+        }
+
+        // Map the TrackerHit object to the corresponding SvtHit object. This
+        // will be used later when setting references for hits on tracks.
+        //hit_map[lc_tracker_hit] = tracker_hit; 
+        hits_.push_back(tracker_hit);
+
+    }
+
+    if(hasMCParts) delete mcPartRel_nav;
+
+    return true;
+}
+
+void Tracker2DHitProcessor::finalize() { 
+}
+
+DECLARE_PROCESSOR(Tracker2DHitProcessor); 


### PR DESCRIPTION
Added new TrackerHit2DProcessor to get KalmanFullTrack track hit truth information.

KalmanFullTrack TrackerHits are made from 'StripClusterer_SiTrackerHitStrip1D' hits.
We loop over all 'StripClusterer_SiTrackerHitStrip1D' hits in an event and get the SvtRawTrackerHits for each 1D hit. Using the SVTTrueHitRelations we find the SimTrackerHit corresponding to each SvtRawTrackerHit. From the SimTrackerHit we can get the MCParticle that makes the hit.
We create a HPSTR TrackerHit for each 'StripClusterer_SiTrackerHitStrip1D', and add all of the MCParticles found on the 1D hit to that TrackerHit. This TrackerHit collection is saved as a ROOT tuple.

To truth match KalmanFullTrack hits on track to MCParticles, you loop over the hits on a KalmanFullTrack (which are 'StripClusterer_SiTrackerHitStrip1D' hits), and then cross reference those hit IDs with the ROOT TrackerHit collection created in the TrackerHit2DProcessor.