### PR TITLE
Add raw hits on Si clusters in Tracker2DHitProcessor

### DIFF
--- a/processors/include/Tracker2DHitProcessor.h
+++ b/processors/include/Tracker2DHitProcessor.h
@@ -29,6 +29,7 @@
 #include "Collections.h"
 #include "Processor.h"
 #include "Track.h"
+#include "RawSvtHit.h"
 #include "TrackerHit.h"
 #include "Event.h"
 
@@ -82,7 +83,12 @@ class Tracker2DHitProcessor : public Processor {
         std::string hitCollLcio_{"RotatedHelicalTrackHits"};
         std::string hitCollRoot_{"RotatedHelicalTrackHits"};
 
+        std::vector<RawSvtHit*> rawhits_{};
+        std::string rawhitCollRoot_{"fspOnTrackRawHits"};
+        std::string hitFitsCollLcio_{"SVTFittedRawTrackerHits"};
+
         std::string mcPartRelLcio_{"RotatedHelicalTrackMCRelations"};
+
 
         //Debug Level
         int debug_{0};

--- a/processors/src/Tracker2DHitProcessor.cxx
+++ b/processors/src/Tracker2DHitProcessor.cxx
@@ -13,9 +13,11 @@ void Tracker2DHitProcessor::configure(const ParameterSet& parameters) {
     std::cout << "Configuring Tracker2DHitProcessor" << std::endl;
     try
     {
-        debug_          = parameters.getInteger("debug", debug_);
-        hitCollLcio_    = parameters.getString("hitCollLcio", hitCollLcio_);
-        hitCollRoot_    = parameters.getString("hitCollRoot", hitCollRoot_);
+        debug_           = parameters.getInteger("debug", debug_);
+        hitCollLcio_     = parameters.getString("hitCollLcio", hitCollLcio_);
+        hitCollRoot_     = parameters.getString("hitCollRoot", hitCollRoot_);
+        hitFitsCollLcio_   = parameters.getString("hitFitsCollLcio", hitFitsCollLcio_);
+        rawhitCollRoot_  = parameters.getString("rawhitCollRoot", hitCollRoot_);
         mcPartRelLcio_ = parameters.getString("mcPartRelLcio", mcPartRelLcio_);
     }
     catch (std::runtime_error& error)
@@ -27,12 +29,21 @@ void Tracker2DHitProcessor::configure(const ParameterSet& parameters) {
 void Tracker2DHitProcessor::initialize(TTree* tree) {
     // Add branches to tree
     tree->Branch(hitCollRoot_.c_str(), &hits_);
+    if (!rawhitCollRoot_.empty())
+        tree->Branch(rawhitCollRoot_.c_str(), &rawhits_);
 }
 
 bool Tracker2DHitProcessor::process(IEvent* ievent) {
 
     for(int i = 0; i < hits_.size(); i++) delete hits_.at(i);
     hits_.clear();
+
+    if (rawhits_.size() > 0) {
+        for (std::vector<RawSvtHit *>::iterator it = rawhits_.begin(); it != rawhits_.end(); ++it) {
+            delete *it;
+        }
+        rawhits_.clear();
+    }
 
     Event* event = static_cast<Event*> (ievent);
     UTIL::LCRelationNavigator* mcPartRel_nav;
@@ -51,10 +62,10 @@ bool Tracker2DHitProcessor::process(IEvent* ievent) {
 
     //Check to see if MC Particles are in the file
     auto evColls = event->getLCEvent()->getCollectionNames();
-    auto it = std::find (evColls->begin(), evColls->end(), mcPartRelLcio_.c_str());
+    auto mcit = std::find (evColls->begin(), evColls->end(), mcPartRelLcio_.c_str());
     bool hasMCParts = true;
     EVENT::LCCollection* mcPartRel;
-    if(it == evColls->end()) hasMCParts = false;
+    if(mcit == evColls->end()) hasMCParts = false;
     if(hasMCParts)
     {
         mcPartRel = event->getLCCollection(mcPartRelLcio_.c_str());
@@ -68,6 +79,15 @@ bool Tracker2DHitProcessor::process(IEvent* ievent) {
     // TODO: Use an unordered map for faster access
     std::map<EVENT::TrackerHit*, TrackerHit*> hit_map;
 
+    EVENT::LCCollection* raw_svt_hit_fits = nullptr;
+    auto fitit = std::find (evColls->begin(), evColls->end(), hitFitsCollLcio_.c_str());
+    bool hasFits = true;
+    if(fitit == evColls->end()) hasFits = false;
+    if(hasFits)
+    {
+        raw_svt_hit_fits = event->getLCCollection(hitFitsCollLcio_.c_str());
+    }
+
     // Loop over all of the 2D hits in the LCIO event and add them to the 
     // HPS event
     for (int ihit = 0; ihit < tracker_hits->getNumberOfElements(); ++ihit) { 
@@ -79,13 +99,19 @@ bool Tracker2DHitProcessor::process(IEvent* ievent) {
             std::cout << "tracker hit lcio id: " << lc_tracker_hit->id() << std::endl;
 
         // Build a TrackerHit
-        TrackerHit* tracker_hit = utils::buildTrackerHit(lc_tracker_hit);
+        TrackerHit* tracker_hit = utils::buildTrackerHit(lc_tracker_hit,true,0);
+        std::vector<RawSvtHit*> rawSvthits;
+        utils::addRawInfoTo3dHit(tracker_hit, lc_tracker_hit, raw_svt_hit_fits,&rawSvthits,0);
+        for (auto rhit : rawSvthits)
+            rawhits_.push_back(rhit);
+
 
         if(hasMCParts)
         {
             //Get the SvtRawTrackerHits that make up the 2D hit
             EVENT::LCObjectVec rawHits = lc_tracker_hit->getRawHits(); 
-            for(int irawhit = 0; irawhit < rawHits.size(); ++irawhit){
+            for(int irawhit = 0; irawhit < rawHits.size(); ++irawhit)
+            {
                 IMPL::TrackerHitImpl* rawhit = static_cast<IMPL::TrackerHitImpl*>(rawHits.at(irawhit));
                 if(debug_ > 0)
                     std::cout << "rawhit on track has lcio id: " << rawhit->id() << std::endl;
@@ -108,10 +134,10 @@ bool Tracker2DHitProcessor::process(IEvent* ievent) {
                 // Get all the MC Particle IDs associated to the hit
                 for(int ipart = 0; ipart < mcPart_list.size(); ipart++)
                 {
-                    IMPL::MCParticleImpl* lc_particle
-                        = static_cast<IMPL::MCParticleImpl*>(mcPart_list.at(ipart));
-                    tracker_hit->addMCPartID(lc_particle->id());
-                    if(debug_ > 0) std::cout << "Has Related MC Particle with ID " << lc_particle->id() << std::endl;
+                IMPL::MCParticleImpl* lc_particle
+                = static_cast<IMPL::MCParticleImpl*>(mcPart_list.at(ipart));
+                tracker_hit->addMCPartID(lc_particle->id());
+                if(debug_ > 0) std::cout << "Has Related MC Particle with ID " << lc_particle->id() << std::endl;
                 }
                 */
             }


### PR DESCRIPTION
Similarly to the problem observed in the creation of the FSPParticle object, if we want to include clusters in an ntupple for our analysis the asssociated processor, Trcker2DHitProcessor, has empty pointers to the rawhits inside of the cluster object it puts in your output root file. Cam wanted to do a speed run of how fast he could write it :), so now we have this version of the Tracker2DHitProcessor with populated clusters. I will include in this push request below a record of the validation tests I performed to see if it was worthy to be put into master.