### PR TITLE
Remove use of `TObject::Clone` in `NewVtxAnaProcessor`

### DIFF
--- a/processors/config/anaSimps_2016_cfg.py
+++ b/processors/config/anaSimps_2016_cfg.py
@@ -43,7 +43,7 @@ vtxana.parameters["mcColl"] = "MCParticle"
 vtxana.parameters["hitColl"] = "SiClustersOnTrackOnPartOnUVtx"
 vtxana.parameters["analysis"] = "vertex"
 vtxana.parameters["vtxSelectionjson"] = os.environ['HPSTR_BASE']+"/analysis/selections/simps/vertexSelection_2016_simp_preselection.json"
-vtxana.parameters["histoCfg"] = os.environ['HPSTR_BASE']+"/analysis/plotconfigs/tracking/simps/vtxAnalysis_2016_simp_reach_light.json"
+vtxana.parameters["histoCfg"] = os.environ['HPSTR_BASE']+"/analysis/plotconfigs/tracking/simps/vtxAnalysis_2016_simp_reach.json"
 vtxana.parameters["mcHistoCfg"] = os.environ['HPSTR_BASE']+'/analysis/plotconfigs/mc/basicMC.json'
 #####
 vtxana.parameters["beamE"] = base.beamE[str(options.year)]

--- a/processors/src/NewVertexAnaProcessor.cxx
+++ b/processors/src/NewVertexAnaProcessor.cxx
@@ -324,9 +324,7 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
 
         Vertex* vtx = vtxs_->at(i_vtx);
         Particle* ele = nullptr;
-        Track* ele_trk = nullptr;
         Particle* pos = nullptr;
-        Track* pos_trk = nullptr;
 
         //Trigger requirement - *really hate* having to do it here for each vertex.
 
@@ -342,19 +340,19 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
         }
 
         if (debug_) std::cout << "got parts" << std::endl;
-        ele_trk = (Track*) ele->getTrack().Clone();
-        pos_trk = (Track*) pos->getTrack().Clone();
+        Track ele_trk = ele->getTrack();
+        Track pos_trk = pos->getTrack();
 
         //Beam Position Corrections
-        ele_trk->applyCorrection("z0", beamPosCorrections_.at(1));
-        pos_trk->applyCorrection("z0", beamPosCorrections_.at(1));
+        ele_trk.applyCorrection("z0", beamPosCorrections_.at(1));
+        pos_trk.applyCorrection("z0", beamPosCorrections_.at(1));
         //Track Time Corrections
-        ele_trk->applyCorrection("track_time",eleTrackTimeBias_);
-        pos_trk->applyCorrection("track_time", posTrackTimeBias_);
+        ele_trk.applyCorrection("track_time",eleTrackTimeBias_);
+        pos_trk.applyCorrection("track_time", posTrackTimeBias_);
 
         //Add the momenta to the tracks - do not do that
-        //ele_trk->setMomentum(ele->getMomentum()[0],ele->getMomentum()[1],ele->getMomentum()[2]);
-        //pos_trk->setMomentum(pos->getMomentum()[0],pos->getMomentum()[1],pos->getMomentum()[2]);
+        //ele_trk.setMomentum(ele->getMomentum()[0],ele->getMomentum()[1],ele->getMomentum()[2]);
+        //pos_trk.setMomentum(pos->getMomentum()[0],pos->getMomentum()[1],pos->getMomentum()[2]);
 
         double ele_E = ele->getEnergy();
         double pos_E = pos->getEnergy();
@@ -366,21 +364,21 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
 
         //Compute analysis variables here.
         TLorentzVector p_ele;
-        p_ele.SetPxPyPzE(ele_trk->getMomentum()[0],ele_trk->getMomentum()[1],ele_trk->getMomentum()[2],ele->getEnergy());
+        p_ele.SetPxPyPzE(ele_trk.getMomentum()[0],ele_trk.getMomentum()[1],ele_trk.getMomentum()[2],ele->getEnergy());
         TLorentzVector p_pos;
-        p_pos.SetPxPyPzE(pos_trk->getMomentum()[0],pos_trk->getMomentum()[1],pos_trk->getMomentum()[2],ele->getEnergy());
+        p_pos.SetPxPyPzE(pos_trk.getMomentum()[0],pos_trk.getMomentum()[1],pos_trk.getMomentum()[2],ele->getEnergy());
 
         //Tracks in opposite volumes - useless
-        //if (!vtxSelector->passCutLt("eleposTanLambaProd_lt",ele_trk->getTanLambda() * pos_trk->getTanLambda(),weight))
+        //if (!vtxSelector->passCutLt("eleposTanLambaProd_lt",ele_trk.getTanLambda() * pos_trk.getTanLambda(),weight))
         //  continue;
 
         if (debug_) std::cout << "start selection" << std::endl;
         //Ele Track Time
-        if (!vtxSelector->passCutLt("eleTrkTime_lt",fabs(ele_trk->getTrackTime()),weight))
+        if (!vtxSelector->passCutLt("eleTrkTime_lt",fabs(ele_trk.getTrackTime()),weight))
             continue;
 
         //Pos Track Time
-        if (!vtxSelector->passCutLt("posTrkTime_lt",fabs(pos_trk->getTrackTime()),weight))
+        if (!vtxSelector->passCutLt("posTrkTime_lt",fabs(pos_trk.getTrackTime()),weight))
             continue;
 
         //Ele Track-cluster match
@@ -419,46 +417,46 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
             continue;
 
         //Ele Track-Cluster Time Difference
-        if (!vtxSelector->passCutLt("eleTrkCluTimeDiff_lt",fabs(ele_trk->getTrackTime() - corr_eleClusterTime),weight))
+        if (!vtxSelector->passCutLt("eleTrkCluTimeDiff_lt",fabs(ele_trk.getTrackTime() - corr_eleClusterTime),weight))
             continue;
 
         //Pos Track-Cluster Time Difference
-        if (!vtxSelector->passCutLt("posTrkCluTimeDiff_lt",fabs(pos_trk->getTrackTime() - corr_posClusterTime),weight))
+        if (!vtxSelector->passCutLt("posTrkCluTimeDiff_lt",fabs(pos_trk.getTrackTime() - corr_posClusterTime),weight))
             continue;
 
         TVector3 ele_mom;
         //ele_mom.SetX(ele->getMomentum()[0]);
         //ele_mom.SetY(ele->getMomentum()[1]);
         //ele_mom.SetZ(ele->getMomentum()[2]);
-        ele_mom.SetX(ele_trk->getMomentum()[0]);
-        ele_mom.SetY(ele_trk->getMomentum()[1]);
-        ele_mom.SetZ(ele_trk->getMomentum()[2]);
+        ele_mom.SetX(ele_trk.getMomentum()[0]);
+        ele_mom.SetY(ele_trk.getMomentum()[1]);
+        ele_mom.SetZ(ele_trk.getMomentum()[2]);
 
 
         TVector3 pos_mom;
         //pos_mom.SetX(pos->getMomentum()[0]);
         //pos_mom.SetY(pos->getMomentum()[1]);
         //pos_mom.SetZ(pos->getMomentum()[2]);
-        pos_mom.SetX(pos_trk->getMomentum()[0]);
-        pos_mom.SetY(pos_trk->getMomentum()[1]);
-        pos_mom.SetZ(pos_trk->getMomentum()[2]);
+        pos_mom.SetX(pos_trk.getMomentum()[0]);
+        pos_mom.SetY(pos_trk.getMomentum()[1]);
+        pos_mom.SetZ(pos_trk.getMomentum()[2]);
 
 
 
         //Ele Track Quality - Chi2
-        if (!vtxSelector->passCutLt("eleTrkChi2_lt",ele_trk->getChi2(),weight))
+        if (!vtxSelector->passCutLt("eleTrkChi2_lt",ele_trk.getChi2(),weight))
             continue;
 
         //Pos Track Quality - Chi2
-        if (!vtxSelector->passCutLt("posTrkChi2_lt",pos_trk->getChi2(),weight))
+        if (!vtxSelector->passCutLt("posTrkChi2_lt",pos_trk.getChi2(),weight))
             continue;
 
         //Ele Track Quality - Chi2Ndf
-        if (!vtxSelector->passCutLt("eleTrkChi2Ndf_lt",ele_trk->getChi2Ndf(),weight))
+        if (!vtxSelector->passCutLt("eleTrkChi2Ndf_lt",ele_trk.getChi2Ndf(),weight))
             continue;
 
         //Pos Track Quality - Chi2Ndf
-        if (!vtxSelector->passCutLt("posTrkChi2Ndf_lt",pos_trk->getChi2Ndf(),weight))
+        if (!vtxSelector->passCutLt("posTrkChi2Ndf_lt",pos_trk.getChi2Ndf(),weight))
             continue;
 
         //Beam Electron cut
@@ -474,8 +472,8 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
             continue;
 
         //Ele nHits
-        int ele2dHits = ele_trk->getTrackerHitCount();
-        if (!ele_trk->isKalmanTrack())
+        int ele2dHits = ele_trk.getTrackerHitCount();
+        if (!ele_trk.isKalmanTrack())
             ele2dHits*=2;
 
         if (!vtxSelector->passCutGt("eleN2Dhits_gt",ele2dHits,weight))  {
@@ -483,8 +481,8 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
         }
 
         //Pos nHits
-        int pos2dHits = pos_trk->getTrackerHitCount();
-        if (!pos_trk->isKalmanTrack())
+        int pos2dHits = pos_trk.getTrackerHitCount();
+        if (!pos_trk.isKalmanTrack())
             pos2dHits*=2;
 
         if (!vtxSelector->passCutGt("posN2Dhits_gt",pos2dHits,weight))  {
@@ -492,11 +490,11 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
         }
 
         //Less than 4 shared hits for ele/pos track
-        if (!vtxSelector->passCutLt("eleNshared_lt",ele_trk->getNShared(),weight)) {
+        if (!vtxSelector->passCutLt("eleNshared_lt",ele_trk.getNShared(),weight)) {
             continue;
         }
 
-        if (!vtxSelector->passCutLt("posNshared_lt",pos_trk->getNShared(),weight)) {
+        if (!vtxSelector->passCutLt("posNshared_lt",pos_trk.getNShared(),weight)) {
             continue;
         }
 
@@ -518,60 +516,60 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
         _vtx_histos->Fill1DVertex(vtx,
                 ele,
                 pos,
-                ele_trk,
-                pos_trk,
+                &ele_trk,
+                &pos_trk,
                 weight);
 
         if (debug_) std::cout << "fill track histos" << std::endl;
         double ele_pos_dt = corr_eleClusterTime - corr_posClusterTime;
         double psum = ele_mom.Mag()+pos_mom.Mag();
 
-        _vtx_histos->Fill1DTrack(ele_trk,weight, "ele_");
-        _vtx_histos->Fill1DTrack(pos_trk,weight, "pos_");
+        _vtx_histos->Fill1DTrack(&ele_trk,weight, "ele_");
+        _vtx_histos->Fill1DTrack(&pos_trk,weight, "pos_");
         _vtx_histos->Fill1DHisto("ele_track_n2dhits_h", ele2dHits, weight);
         _vtx_histos->Fill1DHisto("pos_track_n2dhits_h", pos2dHits, weight);
         _vtx_histos->Fill1DHisto("vtx_Psum_h", p_ele.P()+p_pos.P(), weight);
         _vtx_histos->Fill1DHisto("vtx_Esum_h", ele_E + pos_E, weight);
         _vtx_histos->Fill1DHisto("ele_pos_clusTimeDiff_h", (corr_eleClusterTime - corr_posClusterTime), weight);
-        _vtx_histos->Fill2DHisto("ele_vtxZ_iso_hh", TMath::Min(ele_trk->getIsolation(0), ele_trk->getIsolation(1)), vtx->getZ(), weight);
-        _vtx_histos->Fill2DHisto("pos_vtxZ_iso_hh", TMath::Min(pos_trk->getIsolation(0), pos_trk->getIsolation(1)), vtx->getZ(), weight);
+        _vtx_histos->Fill2DHisto("ele_vtxZ_iso_hh", TMath::Min(ele_trk.getIsolation(0), ele_trk.getIsolation(1)), vtx->getZ(), weight);
+        _vtx_histos->Fill2DHisto("pos_vtxZ_iso_hh", TMath::Min(pos_trk.getIsolation(0), pos_trk.getIsolation(1)), vtx->getZ(), weight);
         _vtx_histos->Fill2DHistograms(vtx,weight);
-        _vtx_histos->Fill2DTrack(ele_trk,weight,"ele_");
-        _vtx_histos->Fill2DTrack(pos_trk,weight,"pos_");
+        _vtx_histos->Fill2DTrack(&ele_trk,weight,"ele_");
+        _vtx_histos->Fill2DTrack(&pos_trk,weight,"pos_");
         _vtx_histos->Fill1DHisto("mcMass622_h",apMass);
         _vtx_histos->Fill1DHisto("mcZ622_h",apZ);
 
         //New SIMP histos for developing loose preselection cuts
         //2d histos
-        _vtx_histos->Fill2DHisto("ele_clusT_v_ele_trackT_hh", ele_trk->getTrackTime(), corr_eleClusterTime, weight);
-        _vtx_histos->Fill2DHisto("pos_clusT_v_pos_trackT_hh", pos_trk->getTrackTime(), corr_posClusterTime, weight);
-        _vtx_histos->Fill2DHisto("ele_track_time_v_P_hh", ele_trk->getP(), ele_trk->getTrackTime(), weight);
-        _vtx_histos->Fill2DHisto("pos_track_time_v_P_hh", pos_trk->getP(), pos_trk->getTrackTime(), weight);
+        _vtx_histos->Fill2DHisto("ele_clusT_v_ele_trackT_hh", ele_trk.getTrackTime(), corr_eleClusterTime, weight);
+        _vtx_histos->Fill2DHisto("pos_clusT_v_pos_trackT_hh", pos_trk.getTrackTime(), corr_posClusterTime, weight);
+        _vtx_histos->Fill2DHisto("ele_track_time_v_P_hh", ele_trk.getP(), ele_trk.getTrackTime(), weight);
+        _vtx_histos->Fill2DHisto("pos_track_time_v_P_hh", pos_trk.getP(), pos_trk.getTrackTime(), weight);
         _vtx_histos->Fill2DHisto("ele_pos_clusTimeDiff_v_pSum_hh",ele_mom.Mag()+pos_mom.Mag(), ele_pos_dt, weight);
-        _vtx_histos->Fill2DHisto("ele_cluster_energy_v_track_p_hh",ele_trk->getP(), eleClus.getEnergy(), weight);
-        _vtx_histos->Fill2DHisto("pos_cluster_energy_v_track_p_hh",pos_trk->getP(), posClus.getEnergy(), weight);
-        _vtx_histos->Fill2DHisto("ele_track_cluster_dt_v_EoverP_hh",eleClus.getEnergy()/ele_trk->getP(), ele_trk->getTrackTime() - corr_eleClusterTime, weight);
-        _vtx_histos->Fill2DHisto("pos_track_cluster_dt_v_EoverP_hh",posClus.getEnergy()/pos_trk->getP(), pos_trk->getTrackTime() - corr_posClusterTime, weight);
-        _vtx_histos->Fill2DHisto("ele_track_clus_dt_v_p_hh",ele_trk->getP(), ele_trk->getTrackTime() - corr_eleClusterTime, weight);
-        _vtx_histos->Fill2DHisto("pos_track_clus_dt_v_p_hh",pos_trk->getP(), pos_trk->getTrackTime() - corr_posClusterTime, weight);
+        _vtx_histos->Fill2DHisto("ele_cluster_energy_v_track_p_hh",ele_trk.getP(), eleClus.getEnergy(), weight);
+        _vtx_histos->Fill2DHisto("pos_cluster_energy_v_track_p_hh",pos_trk.getP(), posClus.getEnergy(), weight);
+        _vtx_histos->Fill2DHisto("ele_track_cluster_dt_v_EoverP_hh",eleClus.getEnergy()/ele_trk.getP(), ele_trk.getTrackTime() - corr_eleClusterTime, weight);
+        _vtx_histos->Fill2DHisto("pos_track_cluster_dt_v_EoverP_hh",posClus.getEnergy()/pos_trk.getP(), pos_trk.getTrackTime() - corr_posClusterTime, weight);
+        _vtx_histos->Fill2DHisto("ele_track_clus_dt_v_p_hh",ele_trk.getP(), ele_trk.getTrackTime() - corr_eleClusterTime, weight);
+        _vtx_histos->Fill2DHisto("pos_track_clus_dt_v_p_hh",pos_trk.getP(), pos_trk.getTrackTime() - corr_posClusterTime, weight);
         //chi2 2d plots
-        _vtx_histos->Fill2DHisto("ele_track_chi2ndf_v_time_hh", ele_trk->getTrackTime(), ele_trk->getChi2Ndf(), weight);
-        _vtx_histos->Fill2DHisto("ele_track_chi2ndf_v_p_hh", ele_trk->getP(), ele_trk->getChi2Ndf(), weight);
-        _vtx_histos->Fill2DHisto("ele_track_chi2ndf_v_tanlambda_hh", ele_trk->getTanLambda(), ele_trk->getChi2Ndf(), weight);
-        _vtx_histos->Fill2DHisto("ele_track_chi2ndf_v_n2dhits_hh", ele2dHits, ele_trk->getChi2Ndf(), weight);
+        _vtx_histos->Fill2DHisto("ele_track_chi2ndf_v_time_hh", ele_trk.getTrackTime(), ele_trk.getChi2Ndf(), weight);
+        _vtx_histos->Fill2DHisto("ele_track_chi2ndf_v_p_hh", ele_trk.getP(), ele_trk.getChi2Ndf(), weight);
+        _vtx_histos->Fill2DHisto("ele_track_chi2ndf_v_tanlambda_hh", ele_trk.getTanLambda(), ele_trk.getChi2Ndf(), weight);
+        _vtx_histos->Fill2DHisto("ele_track_chi2ndf_v_n2dhits_hh", ele2dHits, ele_trk.getChi2Ndf(), weight);
 
-        _vtx_histos->Fill2DHisto("pos_track_chi2ndf_v_time_hh", pos_trk->getTrackTime(), pos_trk->getChi2Ndf(), weight);
-        _vtx_histos->Fill2DHisto("pos_track_chi2ndf_v_p_hh", pos_trk->getP(), pos_trk->getChi2Ndf(), weight);
-        _vtx_histos->Fill2DHisto("pos_track_chi2ndf_v_tanlambda_hh", pos_trk->getTanLambda(), pos_trk->getChi2Ndf(), weight);
-        _vtx_histos->Fill2DHisto("pos_track_chi2ndf_v_n2dhits_hh", pos2dHits, pos_trk->getChi2Ndf(), weight);
+        _vtx_histos->Fill2DHisto("pos_track_chi2ndf_v_time_hh", pos_trk.getTrackTime(), pos_trk.getChi2Ndf(), weight);
+        _vtx_histos->Fill2DHisto("pos_track_chi2ndf_v_p_hh", pos_trk.getP(), pos_trk.getChi2Ndf(), weight);
+        _vtx_histos->Fill2DHisto("pos_track_chi2ndf_v_tanlambda_hh", pos_trk.getTanLambda(), pos_trk.getChi2Ndf(), weight);
+        _vtx_histos->Fill2DHisto("pos_track_chi2ndf_v_n2dhits_hh", pos2dHits, pos_trk.getChi2Ndf(), weight);
 
-        _vtx_histos->Fill2DHisto("ele_track_p_v_tanlambda_hh", ele_trk->getTanLambda(), ele_trk->getP(), weight);
-        _vtx_histos->Fill2DHisto("pos_track_p_v_tanlambda_hh", pos_trk->getTanLambda(), pos_trk->getP(), weight);
+        _vtx_histos->Fill2DHisto("ele_track_p_v_tanlambda_hh", ele_trk.getTanLambda(), ele_trk.getP(), weight);
+        _vtx_histos->Fill2DHisto("pos_track_p_v_tanlambda_hh", pos_trk.getTanLambda(), pos_trk.getP(), weight);
 
 
         //1d histos
-        _vtx_histos->Fill1DHisto("ele_track_clus_dt_h", ele_trk->getTrackTime() - corr_eleClusterTime, weight);
-        _vtx_histos->Fill1DHisto("pos_track_clus_dt_h", pos_trk->getTrackTime() - corr_posClusterTime, weight);
+        _vtx_histos->Fill1DHisto("ele_track_clus_dt_h", ele_trk.getTrackTime() - corr_eleClusterTime, weight);
+        _vtx_histos->Fill1DHisto("pos_track_clus_dt_h", pos_trk.getTrackTime() - corr_posClusterTime, weight);
 
         passVtxPresel = true;
 
@@ -633,30 +631,27 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
 
             //Compute analysis variables here.
 
-            Track * ele_trk = nullptr;
-            ele_trk = (Track*) ele->getTrack().Clone();
-
-            Track * pos_trk = nullptr;
-            pos_trk = (Track*) pos->getTrack().Clone();
+            Track ele_trk = ele->getTrack();
+            Track pos_trk = pos->getTrack();
 
             //Beam Position Corrections
-            ele_trk->applyCorrection("z0", beamPosCorrections_.at(1));
-            pos_trk->applyCorrection("z0", beamPosCorrections_.at(1));
+            ele_trk.applyCorrection("z0", beamPosCorrections_.at(1));
+            pos_trk.applyCorrection("z0", beamPosCorrections_.at(1));
             //Track Time Corrections
-            ele_trk->applyCorrection("track_time",eleTrackTimeBias_);
-            pos_trk->applyCorrection("track_time", posTrackTimeBias_);
+            ele_trk.applyCorrection("track_time",eleTrackTimeBias_);
+            pos_trk.applyCorrection("track_time", posTrackTimeBias_);
 
             //Add the momenta to the tracks
-            //ele_trk->setMomentum(ele->getMomentum()[0],ele->getMomentum()[1],ele->getMomentum()[2]);
-            //pos_trk->setMomentum(pos->getMomentum()[0],pos->getMomentum()[1],pos->getMomentum()[2]);
+            //ele_trk.setMomentum(ele->getMomentum()[0],ele->getMomentum()[1],ele->getMomentum()[2]);
+            //pos_trk.setMomentum(pos->getMomentum()[0],pos->getMomentum()[1],pos->getMomentum()[2]);
             TVector3 recEleP(ele->getMomentum()[0],ele->getMomentum()[1],ele->getMomentum()[2]);
             TLorentzVector p_ele;
-            p_ele.SetPxPyPzE(ele_trk->getMomentum()[0],ele_trk->getMomentum()[1],ele_trk->getMomentum()[2], ele_E);
+            p_ele.SetPxPyPzE(ele_trk.getMomentum()[0],ele_trk.getMomentum()[1],ele_trk.getMomentum()[2], ele_E);
             TLorentzVector p_pos;
-            p_pos.SetPxPyPzE(pos_trk->getMomentum()[0],pos_trk->getMomentum()[1],pos_trk->getMomentum()[2], pos_E);
+            p_pos.SetPxPyPzE(pos_trk.getMomentum()[0],pos_trk.getMomentum()[1],pos_trk.getMomentum()[2], pos_E);
 
             //Get the layers hit on each track
-            std::vector<int> ele_hit_layers = ele_trk->getHitLayers();
+            std::vector<int> ele_hit_layers = ele_trk.getHitLayers();
             int ele_Si0 = 0;
             int ele_Si1 = 0;
             int ele_lastlayer = 0;
@@ -668,7 +663,7 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
                 if (layer == 1) ele_Si1++;
             }
 
-            std::vector<int> pos_hit_layers = pos_trk->getHitLayers();
+            std::vector<int> pos_hit_layers = pos_trk.getHitLayers();
             int pos_Si0 = 0;
             int pos_Si1 = 0;
             int pos_lastlayer = 0;
@@ -686,22 +681,22 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
 
             if (debug_) {
                 std::cout<<"Check on ele_Track"<<std::endl;
-                std::cout<<"Number of hits:"<<ele_trk->getTrackerHitCount()<<std::endl;
+                std::cout<<"Number of hits:"<<ele_trk.getTrackerHitCount()<<std::endl;
             }
 
             bool foundL1ele = false;
             bool foundL2ele = false;
-            _ah->InnermostLayerCheck(ele_trk, foundL1ele, foundL2ele);
+            _ah->InnermostLayerCheck(&ele_trk, foundL1ele, foundL2ele);
 
 
             if (debug_) {
                 std::cout<<"Check on pos_Track"<<std::endl;
-                std::cout<<"Number of hits:"<<ele_trk->getTrackerHitCount()<<std::endl;
+                std::cout<<"Number of hits:"<<ele_trk.getTrackerHitCount()<<std::endl;
             }
             bool foundL1pos = false;
             bool foundL2pos = false;
 
-            _ah->InnermostLayerCheck(pos_trk, foundL1pos, foundL2pos);
+            _ah->InnermostLayerCheck(&pos_trk, foundL1pos, foundL2pos);
 
             if (debug_) {
                 std::cout<<"Check on pos_Track"<<std::endl;
@@ -714,11 +709,11 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
                     break;
             }
             //Ele Track Time
-            if (!_reg_vtx_selectors[region]->passCutLt("eleTrkTime_lt",fabs(ele_trk->getTrackTime()),weight))
+            if (!_reg_vtx_selectors[region]->passCutLt("eleTrkTime_lt",fabs(ele_trk.getTrackTime()),weight))
                 continue;
 
             //Pos Track Time
-            if (!_reg_vtx_selectors[region]->passCutLt("posTrkTime_lt",fabs(pos_trk->getTrackTime()),weight))
+            if (!_reg_vtx_selectors[region]->passCutLt("posTrkTime_lt",fabs(pos_trk.getTrackTime()),weight))
                 continue;
 
             //Ele Track-cluster match
@@ -756,38 +751,38 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
                 continue;
 
             //Ele Track-Cluster Time Difference
-            if (!_reg_vtx_selectors[region]->passCutLt("eleTrkCluTimeDiff_lt",fabs(ele_trk->getTrackTime() - corr_eleClusterTime),weight))
+            if (!_reg_vtx_selectors[region]->passCutLt("eleTrkCluTimeDiff_lt",fabs(ele_trk.getTrackTime() - corr_eleClusterTime),weight))
                 continue;
 
             //Pos Track-Cluster Time Difference
-            if (!_reg_vtx_selectors[region]->passCutLt("posTrkCluTimeDiff_lt",fabs(pos_trk->getTrackTime() - corr_posClusterTime),weight))
+            if (!_reg_vtx_selectors[region]->passCutLt("posTrkCluTimeDiff_lt",fabs(pos_trk.getTrackTime() - corr_posClusterTime),weight))
                 continue;
 
             TVector3 ele_mom;
-            ele_mom.SetX(ele_trk->getMomentum()[0]);
-            ele_mom.SetY(ele_trk->getMomentum()[1]);
-            ele_mom.SetZ(ele_trk->getMomentum()[2]);
+            ele_mom.SetX(ele_trk.getMomentum()[0]);
+            ele_mom.SetY(ele_trk.getMomentum()[1]);
+            ele_mom.SetZ(ele_trk.getMomentum()[2]);
 
 
             TVector3 pos_mom;
-            pos_mom.SetX(pos_trk->getMomentum()[0]);
-            pos_mom.SetY(pos_trk->getMomentum()[1]);
-            pos_mom.SetZ(pos_trk->getMomentum()[2]);
+            pos_mom.SetX(pos_trk.getMomentum()[0]);
+            pos_mom.SetY(pos_trk.getMomentum()[1]);
+            pos_mom.SetZ(pos_trk.getMomentum()[2]);
 
             //Ele Track Quality - Chi2
-            if (!_reg_vtx_selectors[region]->passCutLt("eleTrkChi2_lt",ele_trk->getChi2(),weight))
+            if (!_reg_vtx_selectors[region]->passCutLt("eleTrkChi2_lt",ele_trk.getChi2(),weight))
                 continue;
 
             //Pos Track Quality - Chi2
-            if (!_reg_vtx_selectors[region]->passCutLt("posTrkChi2_lt",pos_trk->getChi2(),weight))
+            if (!_reg_vtx_selectors[region]->passCutLt("posTrkChi2_lt",pos_trk.getChi2(),weight))
                 continue;
 
             //Ele Track Quality - Chi2Ndf
-            if (!_reg_vtx_selectors[region]->passCutLt("eleTrkChi2Ndf_lt",ele_trk->getChi2Ndf(),weight))
+            if (!_reg_vtx_selectors[region]->passCutLt("eleTrkChi2Ndf_lt",ele_trk.getChi2Ndf(),weight))
                 continue;
 
             //Pos Track Quality - Chi2Ndf
-            if (!_reg_vtx_selectors[region]->passCutLt("posTrkChi2Ndf_lt",pos_trk->getChi2Ndf(),weight))
+            if (!_reg_vtx_selectors[region]->passCutLt("posTrkChi2Ndf_lt",pos_trk.getChi2Ndf(),weight))
                 continue;
 
             //Beam Electron cut
@@ -803,8 +798,8 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
                 continue;
 
             //Ele nHits
-            int ele2dHits = ele_trk->getTrackerHitCount();
-            if (!ele_trk->isKalmanTrack())
+            int ele2dHits = ele_trk.getTrackerHitCount();
+            if (!ele_trk.isKalmanTrack())
                 ele2dHits*=2;
 
             if (!_reg_vtx_selectors[region]->passCutGt("eleN2Dhits_gt",ele2dHits,weight))  {
@@ -812,8 +807,8 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
             }
 
             //Pos nHits
-            int pos2dHits = pos_trk->getTrackerHitCount();
-            if (!pos_trk->isKalmanTrack())
+            int pos2dHits = pos_trk.getTrackerHitCount();
+            if (!pos_trk.isKalmanTrack())
                 pos2dHits*=2;
 
             if (!_reg_vtx_selectors[region]->passCutGt("posN2Dhits_gt",pos2dHits,weight))  {
@@ -821,11 +816,11 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
             }
 
             //Less than 4 shared hits for ele/pos track
-            if (!_reg_vtx_selectors[region]->passCutLt("eleNshared_lt",ele_trk->getNShared(),weight)) {
+            if (!_reg_vtx_selectors[region]->passCutLt("eleNshared_lt",ele_trk.getNShared(),weight)) {
                 continue;
             }
 
-            if (!_reg_vtx_selectors[region]->passCutLt("posNshared_lt",pos_trk->getNShared(),weight)) {
+            if (!_reg_vtx_selectors[region]->passCutLt("posNshared_lt",pos_trk.getNShared(),weight)) {
                 continue;
             }
 
@@ -881,13 +876,13 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
                 continue;
 
             //No shared hits requirement
-            if (!_reg_vtx_selectors[region]->passCutEq("ele_sharedL0_eq",(int)ele_trk->getSharedLy0(),weight))
+            if (!_reg_vtx_selectors[region]->passCutEq("ele_sharedL0_eq",(int)ele_trk.getSharedLy0(),weight))
                 continue;
-            if (!_reg_vtx_selectors[region]->passCutEq("pos_sharedL0_eq",(int)pos_trk->getSharedLy0(),weight))
+            if (!_reg_vtx_selectors[region]->passCutEq("pos_sharedL0_eq",(int)pos_trk.getSharedLy0(),weight))
                 continue;
-            if (!_reg_vtx_selectors[region]->passCutEq("ele_sharedL1_eq",(int)ele_trk->getSharedLy1(),weight))
+            if (!_reg_vtx_selectors[region]->passCutEq("ele_sharedL1_eq",(int)ele_trk.getSharedLy1(),weight))
                 continue;
-            if (!_reg_vtx_selectors[region]->passCutEq("pos_sharedL1_eq",(int)pos_trk->getSharedLy1(),weight))
+            if (!_reg_vtx_selectors[region]->passCutEq("pos_sharedL1_eq",(int)pos_trk.getSharedLy1(),weight))
                 continue;
 
             //Min vtx Y pos
@@ -905,7 +900,7 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
             if (!_reg_vtx_selectors[region]->passCutLt("volPos_bot", p_pos.Py(), weight))
                 continue;
 
-            if (!_reg_vtx_selectors[region]->passCutLt("deltaZ_lt", std::abs((ele_trk->getZ0()/ele_trk->getTanLambda()) - (pos_trk->getZ0()/pos_trk->getTanLambda())), weight))
+            if (!_reg_vtx_selectors[region]->passCutLt("deltaZ_lt", std::abs((ele_trk.getZ0()/ele_trk.getTanLambda()) - (pos_trk.getZ0()/pos_trk.getTanLambda())), weight))
                 continue;
 
             //If this is MC check if MCParticle matched to the electron track is from rad or recoil
@@ -916,9 +911,9 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
 
                 //Count the number of hits per part on the ele track
                 std::map<int, int> nHits4part;
-                for(int i =0; i < ele_trk->getMcpHits().size(); i++)
+                for(int i =0; i < ele_trk.getMcpHits().size(); i++)
                 {
-                    int partID = ele_trk->getMcpHits().at(i).second;
+                    int partID = ele_trk.getMcpHits().at(i).second;
                     if ( nHits4part.find(partID) == nHits4part.end() )
                     {
                         // not found
@@ -1024,16 +1019,16 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
             double pos_E = pos->getEnergy();
 
             //Compute analysis variables here.
-            Track * ele_trk = (Track*) ele->getTrack().Clone();
-            Track * pos_trk = (Track*) pos->getTrack().Clone();
+            Track ele_trk = ele->getTrack();
+            Track pos_trk = pos->getTrack();
             //Get the shared info - TODO change and improve
             
             //Track Time Corrections
-            ele_trk->applyCorrection("track_time",eleTrackTimeBias_);
-            pos_trk->applyCorrection("track_time", posTrackTimeBias_);
+            ele_trk.applyCorrection("track_time",eleTrackTimeBias_);
+            pos_trk.applyCorrection("track_time", posTrackTimeBias_);
 
             //Get the layers hit on each track
-            std::vector<int> ele_hit_layers = ele_trk->getHitLayers();
+            std::vector<int> ele_hit_layers = ele_trk.getHitLayers();
             int ele_Si0 = 0;
             int ele_Si1 = 0;
             int ele_lastlayer = 0;
@@ -1045,7 +1040,7 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
                 if (layer == 1) ele_Si1++;
             }
 
-            std::vector<int> pos_hit_layers = pos_trk->getHitLayers();
+            std::vector<int> pos_hit_layers = pos_trk.getHitLayers();
             int pos_Si0 = 0;
             int pos_Si1 = 0;
             int pos_lastlayer = 0;
@@ -1073,7 +1068,7 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
             int L2hitCode = 0; // hit code '1111' means truth in L2_ele_ax, L2_ele_ster, L2_pos_ax, L2_pos_ster
             if(!isData_){
                 //Get hit codes. Only sure this works for 2016 KF as is.
-                utils::get2016KFMCTruthHitCodes(ele_trk, pos_trk, L1L2hitCode, L1hitCode, L2hitCode);
+                utils::get2016KFMCTruthHitCodes(&ele_trk, &pos_trk, L1L2hitCode, L1hitCode, L2hitCode);
                 //L1L2 truth hit selection
                 if (!_reg_vtx_selectors[region]->passCutLt("hitCode_lt",((double)L1L2hitCode)-0.5, weight)) continue;
                 if (!_reg_vtx_selectors[region]->passCutGt("hitCode_gt",((double)L1L2hitCode)+0.5, weight)) continue;
@@ -1087,39 +1082,39 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
             //Only calculate isolations if both track L1 and L2 hits exist
             bool hasL1ele = false;
             bool hasL2ele = false;
-            _ah->InnermostLayerCheck(ele_trk, hasL1ele, hasL2ele);
+            _ah->InnermostLayerCheck(&ele_trk, hasL1ele, hasL2ele);
 
             bool hasL1pos = false;
             bool hasL2pos = false;
-            _ah->InnermostLayerCheck(pos_trk, hasL1pos, hasL2pos);
+            _ah->InnermostLayerCheck(&pos_trk, hasL1pos, hasL2pos);
 
             TVector3 ele_mom;
             //ele_mom.SetX(ele->getMomentum()[0]);
             //ele_mom.SetY(ele->getMomentum()[1]);
             //ele_mom.SetZ(ele->getMomentum()[2]);
-            ele_mom.SetX(ele_trk->getMomentum()[0]);
-            ele_mom.SetY(ele_trk->getMomentum()[1]);
-            ele_mom.SetZ(ele_trk->getMomentum()[2]);
+            ele_mom.SetX(ele_trk.getMomentum()[0]);
+            ele_mom.SetY(ele_trk.getMomentum()[1]);
+            ele_mom.SetZ(ele_trk.getMomentum()[2]);
 
 
             TVector3 pos_mom;
             //pos_mom.SetX(pos->getMomentum()[0]);
             //pos_mom.SetY(pos->getMomentum()[1]);
             //pos_mom.SetZ(pos->getMomentum()[2]);
-            pos_mom.SetX(pos_trk->getMomentum()[0]);
-            pos_mom.SetY(pos_trk->getMomentum()[1]);
-            pos_mom.SetZ(pos_trk->getMomentum()[2]);
+            pos_mom.SetX(pos_trk.getMomentum()[0]);
+            pos_mom.SetY(pos_trk.getMomentum()[1]);
+            pos_mom.SetZ(pos_trk.getMomentum()[2]);
 
             double ele_pos_dt = corr_eleClusterTime - corr_posClusterTime;
             double psum = ele_mom.Mag()+pos_mom.Mag();
 
             //Ele nHits
-            int ele2dHits = ele_trk->getTrackerHitCount();
-            if (!ele_trk->isKalmanTrack())
+            int ele2dHits = ele_trk.getTrackerHitCount();
+            if (!ele_trk.isKalmanTrack())
                 ele2dHits*=2;
 
             //pos nHits
-            int pos2dHits = pos_trk->getTrackerHitCount();
+            int pos2dHits = pos_trk.getTrackerHitCount();
 
             if(ts_ != nullptr)
             {
@@ -1130,21 +1125,21 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
             _reg_vtx_histos[region]->Fill1DHisto("n_vtx_h", vtxs_->size()); 
 
             //Add the momenta to the tracks
-            //ele_trk->setMomentum(ele->getMomentum()[0],ele->getMomentum()[1],ele->getMomentum()[2]);
-            //pos_trk->setMomentum(pos->getMomentum()[0],pos->getMomentum()[1],pos->getMomentum()[2]);
+            //ele_trk.setMomentum(ele->getMomentum()[0],ele->getMomentum()[1],ele->getMomentum()[2]);
+            //pos_trk.setMomentum(pos->getMomentum()[0],pos->getMomentum()[1],pos->getMomentum()[2]);
             TVector3 recEleP(ele->getMomentum()[0],ele->getMomentum()[1],ele->getMomentum()[2]);
             TLorentzVector p_ele;
-            p_ele.SetPxPyPzE(ele_trk->getMomentum()[0],ele_trk->getMomentum()[1],ele_trk->getMomentum()[2], ele_E);
+            p_ele.SetPxPyPzE(ele_trk.getMomentum()[0],ele_trk.getMomentum()[1],ele_trk.getMomentum()[2], ele_E);
             TLorentzVector p_pos;
-            p_pos.SetPxPyPzE(pos_trk->getMomentum()[0],pos_trk->getMomentum()[1],pos_trk->getMomentum()[2], pos_E);
+            p_pos.SetPxPyPzE(pos_trk.getMomentum()[0],pos_trk.getMomentum()[1],pos_trk.getMomentum()[2], pos_E);
 
 
             _reg_vtx_histos[region]->Fill2DHistograms(vtx,weight);
             _reg_vtx_histos[region]->Fill1DVertex(vtx,
                     ele,
                     pos,
-                    ele_trk,
-                    pos_trk,
+                    &ele_trk,
+                    &pos_trk,
                     weight);
 
             _reg_vtx_histos[region]->Fill1DHisto("ele_pos_clusTimeDiff_h", (corr_eleClusterTime - corr_posClusterTime), weight);
@@ -1152,10 +1147,10 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
             _reg_vtx_histos[region]->Fill1DHisto("pos_track_n2dhits_h", pos2dHits, weight);
             _reg_vtx_histos[region]->Fill1DHisto("vtx_Psum_h", p_ele.P()+p_pos.P(), weight);
             _reg_vtx_histos[region]->Fill1DHisto("vtx_Esum_h", eleClus.getEnergy()+posClus.getEnergy(), weight);
-            _reg_vtx_histos[region]->Fill2DHisto("ele_vtxZ_iso_hh", TMath::Min(ele_trk->getIsolation(0), ele_trk->getIsolation(1)), vtx->getZ(), weight);
-            _reg_vtx_histos[region]->Fill2DHisto("pos_vtxZ_iso_hh", TMath::Min(pos_trk->getIsolation(0), pos_trk->getIsolation(1)), vtx->getZ(), weight);
-            _reg_vtx_histos[region]->Fill2DTrack(ele_trk,weight,"ele_");
-            _reg_vtx_histos[region]->Fill2DTrack(pos_trk,weight,"pos_");
+            _reg_vtx_histos[region]->Fill2DHisto("ele_vtxZ_iso_hh", TMath::Min(ele_trk.getIsolation(0), ele_trk.getIsolation(1)), vtx->getZ(), weight);
+            _reg_vtx_histos[region]->Fill2DHisto("pos_vtxZ_iso_hh", TMath::Min(pos_trk.getIsolation(0), pos_trk.getIsolation(1)), vtx->getZ(), weight);
+            _reg_vtx_histos[region]->Fill2DTrack(&ele_trk,weight,"ele_");
+            _reg_vtx_histos[region]->Fill2DTrack(&pos_trk,weight,"pos_");
             _reg_vtx_histos[region]->Fill1DHisto("mcMass622_h",apMass);
             _reg_vtx_histos[region]->Fill1DHisto("mcZ622_h",apZ);
             _reg_vtx_histos[region]->Fill1DHisto("mcMass625_h",vdMass);
@@ -1171,13 +1166,13 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
             }
 
             double reconz = vtx->getZ(); 
-            double ele_trk_z0 = ele_trk->getZ0();
-            double ele_trk_z0err = ele_trk->getZ0Err();
-            double pos_trk_z0 = pos_trk->getZ0();
-            double pos_trk_z0err = pos_trk->getZ0Err();
+            double ele_trk_z0 = ele_trk.getZ0();
+            double ele_trk_z0err = ele_trk.getZ0Err();
+            double pos_trk_z0 = pos_trk.getZ0();
+            double pos_trk_z0err = pos_trk.getZ0Err();
 
             //DeltaZ
-            double deltaZ = std::abs( (ele_trk_z0/ele_trk->getTanLambda()) - (pos_trk_z0/pos_trk->getTanLambda()) );
+            double deltaZ = std::abs( (ele_trk_z0/ele_trk.getTanLambda()) - (pos_trk_z0/pos_trk.getTanLambda()) );
             
             //Project vertex to target
             double vtx_proj_x = -999.9;
@@ -1198,8 +1193,8 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
             _reg_vtx_histos[region]->Fill2DHisto("vtx_track_reconz_v_Z0err_hh", pos_trk_z0err, reconz);
             _reg_vtx_histos[region]->Fill2DHisto("recon_z_v_z0_hh", ele_trk_z0, reconz);
             _reg_vtx_histos[region]->Fill2DHisto("recon_z_v_z0_hh", pos_trk_z0, reconz);
-            _reg_vtx_histos[region]->Fill2DHisto("vtx_track_recon_z_v_ABSdz0tanlambda_hh", std::abs((ele_trk_z0/ele_trk->getTanLambda()) - (pos_trk_z0/pos_trk->getTanLambda())), reconz);
-            _reg_vtx_histos[region]->Fill2DHisto("vtx_track_recon_z_v_dz0tanlambda_hh", ((ele_trk_z0/ele_trk->getTanLambda()) - (pos_trk_z0/pos_trk->getTanLambda())), reconz);
+            _reg_vtx_histos[region]->Fill2DHisto("vtx_track_recon_z_v_ABSdz0tanlambda_hh", std::abs((ele_trk_z0/ele_trk.getTanLambda()) - (pos_trk_z0/pos_trk.getTanLambda())), reconz);
+            _reg_vtx_histos[region]->Fill2DHisto("vtx_track_recon_z_v_dz0tanlambda_hh", ((ele_trk_z0/ele_trk.getTanLambda()) - (pos_trk_z0/pos_trk.getTanLambda())), reconz);
 
             _reg_vtx_histos[region]->Fill2DHisto("recon_z_v_cxx_hh", cxx, reconz);
             _reg_vtx_histos[region]->Fill2DHisto("recon_z_v_cyy_hh", cyy, reconz);
@@ -1213,39 +1208,39 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
             _reg_vtx_histos[region]->Fill1DHisto("cyx_h", cyx);
             _reg_vtx_histos[region]->Fill1DHisto("czx_h", czx);
             _reg_vtx_histos[region]->Fill1DHisto("czy_h", czy);
-            _reg_vtx_histos[region]->Fill2DHisto("vtx_track_recon_z_v_z0tanlambda_hh", ele_trk_z0/ele_trk->getTanLambda(), reconz);
-            _reg_vtx_histos[region]->Fill2DHisto("vtx_track_recon_z_v_z0tanlambda_hh", pos_trk_z0/pos_trk->getTanLambda(), reconz);
-            _reg_vtx_histos[region]->Fill2DHisto("ele_clusT_v_ele_trackT_hh", ele_trk->getTrackTime(), corr_eleClusterTime, weight);
-            _reg_vtx_histos[region]->Fill2DHisto("pos_clusT_v_pos_trackT_hh", pos_trk->getTrackTime(), corr_posClusterTime, weight);
-            _reg_vtx_histos[region]->Fill2DHisto("ele_track_time_v_P_hh", ele_trk->getP(), ele_trk->getTrackTime(), weight);
-            _reg_vtx_histos[region]->Fill2DHisto("pos_track_time_v_P_hh", pos_trk->getP(), pos_trk->getTrackTime(), weight);
+            _reg_vtx_histos[region]->Fill2DHisto("vtx_track_recon_z_v_z0tanlambda_hh", ele_trk_z0/ele_trk.getTanLambda(), reconz);
+            _reg_vtx_histos[region]->Fill2DHisto("vtx_track_recon_z_v_z0tanlambda_hh", pos_trk_z0/pos_trk.getTanLambda(), reconz);
+            _reg_vtx_histos[region]->Fill2DHisto("ele_clusT_v_ele_trackT_hh", ele_trk.getTrackTime(), corr_eleClusterTime, weight);
+            _reg_vtx_histos[region]->Fill2DHisto("pos_clusT_v_pos_trackT_hh", pos_trk.getTrackTime(), corr_posClusterTime, weight);
+            _reg_vtx_histos[region]->Fill2DHisto("ele_track_time_v_P_hh", ele_trk.getP(), ele_trk.getTrackTime(), weight);
+            _reg_vtx_histos[region]->Fill2DHisto("pos_track_time_v_P_hh", pos_trk.getP(), pos_trk.getTrackTime(), weight);
             _reg_vtx_histos[region]->Fill2DHisto("ele_pos_clusTimeDiff_v_pSum_hh",ele_mom.Mag()+pos_mom.Mag(), ele_pos_dt, weight);
-            _reg_vtx_histos[region]->Fill2DHisto("ele_cluster_energy_v_track_p_hh",ele_trk->getP(), eleClus.getEnergy(), weight);
-            _reg_vtx_histos[region]->Fill2DHisto("pos_cluster_energy_v_track_p_hh",pos_trk->getP(), posClus.getEnergy(), weight);
-            _reg_vtx_histos[region]->Fill2DHisto("ele_track_cluster_dt_v_EoverP_hh",eleClus.getEnergy()/ele_trk->getP(), ele_trk->getTrackTime() - corr_eleClusterTime, weight);
-            _reg_vtx_histos[region]->Fill2DHisto("pos_track_cluster_dt_v_EoverP_hh",posClus.getEnergy()/pos_trk->getP(), pos_trk->getTrackTime() - corr_posClusterTime, weight);
-            _reg_vtx_histos[region]->Fill2DHisto("ele_track_clus_dt_v_p_hh",ele_trk->getP(), ele_trk->getTrackTime() - corr_eleClusterTime, weight);
-            _reg_vtx_histos[region]->Fill2DHisto("pos_track_clus_dt_v_p_hh",pos_trk->getP(), pos_trk->getTrackTime() - corr_posClusterTime, weight);
-            _reg_vtx_histos[region]->Fill2DHisto("ele_z0_vs_pos_z0_hh",ele_trk->getZ0(), pos_trk->getZ0(), weight);
+            _reg_vtx_histos[region]->Fill2DHisto("ele_cluster_energy_v_track_p_hh",ele_trk.getP(), eleClus.getEnergy(), weight);
+            _reg_vtx_histos[region]->Fill2DHisto("pos_cluster_energy_v_track_p_hh",pos_trk.getP(), posClus.getEnergy(), weight);
+            _reg_vtx_histos[region]->Fill2DHisto("ele_track_cluster_dt_v_EoverP_hh",eleClus.getEnergy()/ele_trk.getP(), ele_trk.getTrackTime() - corr_eleClusterTime, weight);
+            _reg_vtx_histos[region]->Fill2DHisto("pos_track_cluster_dt_v_EoverP_hh",posClus.getEnergy()/pos_trk.getP(), pos_trk.getTrackTime() - corr_posClusterTime, weight);
+            _reg_vtx_histos[region]->Fill2DHisto("ele_track_clus_dt_v_p_hh",ele_trk.getP(), ele_trk.getTrackTime() - corr_eleClusterTime, weight);
+            _reg_vtx_histos[region]->Fill2DHisto("pos_track_clus_dt_v_p_hh",pos_trk.getP(), pos_trk.getTrackTime() - corr_posClusterTime, weight);
+            _reg_vtx_histos[region]->Fill2DHisto("ele_z0_vs_pos_z0_hh",ele_trk.getZ0(), pos_trk.getZ0(), weight);
 
             //chi2 2d plots
-            _reg_vtx_histos[region]->Fill2DHisto("ele_track_chi2ndf_v_time_hh", ele_trk->getTrackTime(), ele_trk->getChi2Ndf(), weight);
-            _reg_vtx_histos[region]->Fill2DHisto("ele_track_chi2ndf_v_p_hh", ele_trk->getP(), ele_trk->getChi2Ndf(), weight);
-            _reg_vtx_histos[region]->Fill2DHisto("ele_track_chi2ndf_v_tanlambda_hh", ele_trk->getTanLambda(), ele_trk->getChi2Ndf(), weight);
-            _reg_vtx_histos[region]->Fill2DHisto("ele_track_chi2ndf_v_n2dhits_hh", ele2dHits, ele_trk->getChi2Ndf(), weight);
+            _reg_vtx_histos[region]->Fill2DHisto("ele_track_chi2ndf_v_time_hh", ele_trk.getTrackTime(), ele_trk.getChi2Ndf(), weight);
+            _reg_vtx_histos[region]->Fill2DHisto("ele_track_chi2ndf_v_p_hh", ele_trk.getP(), ele_trk.getChi2Ndf(), weight);
+            _reg_vtx_histos[region]->Fill2DHisto("ele_track_chi2ndf_v_tanlambda_hh", ele_trk.getTanLambda(), ele_trk.getChi2Ndf(), weight);
+            _reg_vtx_histos[region]->Fill2DHisto("ele_track_chi2ndf_v_n2dhits_hh", ele2dHits, ele_trk.getChi2Ndf(), weight);
 
-            _reg_vtx_histos[region]->Fill2DHisto("pos_track_chi2ndf_v_time_hh", pos_trk->getTrackTime(), pos_trk->getChi2Ndf(), weight);
-            _reg_vtx_histos[region]->Fill2DHisto("pos_track_chi2ndf_v_p_hh", pos_trk->getP(), pos_trk->getChi2Ndf(), weight);
-            _reg_vtx_histos[region]->Fill2DHisto("pos_track_chi2ndf_v_tanlambda_hh", pos_trk->getTanLambda(), pos_trk->getChi2Ndf(), weight);
-            _reg_vtx_histos[region]->Fill2DHisto("pos_track_chi2ndf_v_n2dhits_hh", pos2dHits, pos_trk->getChi2Ndf(), weight);
+            _reg_vtx_histos[region]->Fill2DHisto("pos_track_chi2ndf_v_time_hh", pos_trk.getTrackTime(), pos_trk.getChi2Ndf(), weight);
+            _reg_vtx_histos[region]->Fill2DHisto("pos_track_chi2ndf_v_p_hh", pos_trk.getP(), pos_trk.getChi2Ndf(), weight);
+            _reg_vtx_histos[region]->Fill2DHisto("pos_track_chi2ndf_v_tanlambda_hh", pos_trk.getTanLambda(), pos_trk.getChi2Ndf(), weight);
+            _reg_vtx_histos[region]->Fill2DHisto("pos_track_chi2ndf_v_n2dhits_hh", pos2dHits, pos_trk.getChi2Ndf(), weight);
 
-            _reg_vtx_histos[region]->Fill2DHisto("ele_track_p_v_tanlambda_hh", ele_trk->getTanLambda(), ele_trk->getP(), weight);
-            _reg_vtx_histos[region]->Fill2DHisto("pos_track_p_v_tanlambda_hh", pos_trk->getTanLambda(), pos_trk->getP(), weight);
+            _reg_vtx_histos[region]->Fill2DHisto("ele_track_p_v_tanlambda_hh", ele_trk.getTanLambda(), ele_trk.getP(), weight);
+            _reg_vtx_histos[region]->Fill2DHisto("pos_track_p_v_tanlambda_hh", pos_trk.getTanLambda(), pos_trk.getP(), weight);
 
 
             //1d histos
-            _reg_vtx_histos[region]->Fill1DHisto("ele_track_clus_dt_h", ele_trk->getTrackTime() - corr_eleClusterTime, weight);
-            _reg_vtx_histos[region]->Fill1DHisto("pos_track_clus_dt_h", pos_trk->getTrackTime() - corr_posClusterTime, weight);
+            _reg_vtx_histos[region]->Fill1DHisto("ele_track_clus_dt_h", ele_trk.getTrackTime() - corr_eleClusterTime, weight);
+            _reg_vtx_histos[region]->Fill1DHisto("pos_track_clus_dt_h", pos_trk.getTrackTime() - corr_posClusterTime, weight);
  
 
             //TODO put this in the Vertex!
@@ -1294,39 +1289,39 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
                 _reg_tuples[region]->setVariableValue("unc_vtx_deltaZ", deltaZ);
 
                 //track vars
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_p", ele_trk->getP());
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_t", ele_trk->getTrackTime());
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_d0", ele_trk->getD0());
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_phi0", ele_trk->getPhi());
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_omega", ele_trk->getOmega());
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_tanLambda", ele_trk->getTanLambda());
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_z0", ele_trk->getZ0());
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_chi2ndf", ele_trk->getChi2Ndf());
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_clust_dt", ele_trk->getTrackTime() - corr_eleClusterTime);
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_z0Err",ele_trk->getZ0Err());
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_d0Err", ele_trk->getD0Err());
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_tanLambdaErr", ele_trk->getTanLambdaErr());
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_PhiErr", ele_trk->getPhiErr());
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_OmegaErr", ele_trk->getOmegaErr());
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_p", ele_trk.getP());
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_t", ele_trk.getTrackTime());
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_d0", ele_trk.getD0());
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_phi0", ele_trk.getPhi());
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_omega", ele_trk.getOmega());
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_tanLambda", ele_trk.getTanLambda());
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_z0", ele_trk.getZ0());
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_chi2ndf", ele_trk.getChi2Ndf());
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_clust_dt", ele_trk.getTrackTime() - corr_eleClusterTime);
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_z0Err",ele_trk.getZ0Err());
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_d0Err", ele_trk.getD0Err());
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_tanLambdaErr", ele_trk.getTanLambdaErr());
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_PhiErr", ele_trk.getPhiErr());
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_OmegaErr", ele_trk.getOmegaErr());
                 _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_nhits",ele2dHits);
                 _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_lastlayer",ele_lastlayer);
                 _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_si0",ele_Si0);
                 _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_si1",ele_Si1);
 
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_p", pos_trk->getP());
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_t", pos_trk->getTrackTime());
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_d0", pos_trk->getD0());
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_phi0", pos_trk->getPhi());
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_omega", pos_trk->getOmega());
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_tanLambda", pos_trk->getTanLambda());
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_z0", pos_trk->getZ0());
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_chi2ndf", pos_trk->getChi2Ndf());
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_clust_dt", pos_trk->getTrackTime() - corr_posClusterTime);
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_z0Err",pos_trk->getZ0Err());
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_d0Err", pos_trk->getD0Err());
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_tanLambdaErr", pos_trk->getTanLambdaErr());
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_PhiErr", pos_trk->getPhiErr());
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_OmegaErr", pos_trk->getOmegaErr());
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_p", pos_trk.getP());
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_t", pos_trk.getTrackTime());
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_d0", pos_trk.getD0());
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_phi0", pos_trk.getPhi());
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_omega", pos_trk.getOmega());
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_tanLambda", pos_trk.getTanLambda());
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_z0", pos_trk.getZ0());
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_chi2ndf", pos_trk.getChi2Ndf());
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_clust_dt", pos_trk.getTrackTime() - corr_posClusterTime);
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_z0Err",pos_trk.getZ0Err());
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_d0Err", pos_trk.getD0Err());
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_tanLambdaErr", pos_trk.getTanLambdaErr());
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_PhiErr", pos_trk.getPhiErr());
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_OmegaErr", pos_trk.getOmegaErr());
                 _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_nhits",pos2dHits);
                 _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_lastlayer",pos_lastlayer);
                 _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_si0",pos_Si0);
@@ -1342,18 +1337,18 @@ bool NewVertexAnaProcessor::process(IEvent* ievent) {
                 _reg_tuples[region]->setVariableValue("unc_vtx_pos_clust_corr_t",corr_posClusterTime);
                 _reg_tuples[region]->setVariableValue("run_number", evth_->getRunNumber());
 
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_ecal_x", ele_trk->getPositionAtEcal().at(0));
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_ecal_y", ele_trk->getPositionAtEcal().at(1));
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_z", ele_trk->getPosition().at(2));
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_ecal_x", pos_trk->getPositionAtEcal().at(0));
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_ecal_y", pos_trk->getPositionAtEcal().at(1));
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_z", pos_trk->getPosition().at(2));
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_px", ele_trk->getMomentum().at(0));
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_py", ele_trk->getMomentum().at(1));
-                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_pz", ele_trk->getMomentum().at(2));
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_px", pos_trk->getMomentum().at(0));
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_py", pos_trk->getMomentum().at(1));
-                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_pz", pos_trk->getMomentum().at(2));
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_ecal_x", ele_trk.getPositionAtEcal().at(0));
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_ecal_y", ele_trk.getPositionAtEcal().at(1));
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_z", ele_trk.getPosition().at(2));
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_ecal_x", pos_trk.getPositionAtEcal().at(0));
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_ecal_y", pos_trk.getPositionAtEcal().at(1));
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_z", pos_trk.getPosition().at(2));
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_px", ele_trk.getMomentum().at(0));
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_py", ele_trk.getMomentum().at(1));
+                _reg_tuples[region]->setVariableValue("unc_vtx_ele_track_pz", ele_trk.getMomentum().at(2));
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_px", pos_trk.getMomentum().at(0));
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_py", pos_trk.getMomentum().at(1));
+                _reg_tuples[region]->setVariableValue("unc_vtx_pos_track_pz", pos_trk.getMomentum().at(2));
 
                 _reg_tuples[region]->fill();
             }


### PR DESCRIPTION
The use of `TObject::Clone` on the tracks within a vertex is causing a small but measurable memory leak in `NewVtxAnaProcessor`. Using `memory_profiler` to measure and plot the memory usage.

On the current master branch, we see a steady increase in the memory usage as events are processed.
![hpstr-master](https://github.com/JeffersonLab/hpstr/assets/31970302/3e20531f-5bab-4d58-a072-0717f6899aa6)

While on this branch, the memory usage is stabilized to (roughly) the same value which is the core design principle of ROOT's serialization technique with TTrees.
![hpstr-rm-clone](https://github.com/JeffersonLab/hpstr/assets/31970302/1fd8a75b-c257-463d-8363-d4eeea82c31e)

We can even process the full 10M event sample without reaching the memory used in the 1M-event-limited run on master.
![hpstr-rm-clone-full-10M](https://github.com/JeffersonLab/hpstr/assets/31970302/f71c9d2c-383f-441f-a722-2454b6b6210c)

## Context
I am using [hps-env:2024.01.23](https://github.com/tomeichlersmith/hps-env/releases/tag/2024.01.23) to build and run hpstr (look there for details of the dependencies). What I do want to emphasize is that I am running with C++17 enabled.
```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 4d701c5..d3edaf8 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,9 @@ cmake_minimum_required(VERSION 3.18)
 
 project(hpstr)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_C_STANDARD 14)
+set(CMAKE_C_STANDARD 17)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
 if(NOT CMAKE_BUILD_TYPE)
```
which is NOT on this branch and is not tested.
