### PR TITLE
Added support for biasing vertices in analysis tools

### DIFF
--- a/event/include/Particle.h
+++ b/event/include/Particle.h
@@ -140,7 +140,10 @@ class Particle : public TObject {
         int getPDG() const { return pdg_; }; 
         
         /** @return The particle energy in GeV. */
-        double getEnergy() const { return energy_; }; 
+        double getEnergy() const { return energy_; };
+
+        /** @return The particle momentum  in GeV. */
+        double getP() const {return sqrt(px_*px_ + py_*py_ + pz_*pz_);};
         
         /** @return The invariant mass of the particle in GeV. */
         double getMass() const { return mass_; }; 

--- a/event/include/Vertex.h
+++ b/event/include/Vertex.h
@@ -15,6 +15,7 @@
 #include <TRefArray.h>
 #include <TRef.h>
 #include <TVector3.h>
+#include <TLorentzVector.h>
 
 //TODO make float/doubles accordingly.
 
@@ -68,6 +69,13 @@ class Vertex : public TObject {
          */
         void setVtxParameters(const std::vector<float>& parameters);
 
+        void setVtxParameters(const TLorentzVector& p1,
+			      const TLorentzVector& p2);
+  
+        void setVtxParameters(const TVector3& p1,
+			      const TVector3& p2,
+			      const double m) ;
+    
         /** Set the type */
         void setType(const std::string& type) {type_ = type;}
 

--- a/event/src/Vertex.cxx
+++ b/event/src/Vertex.cxx
@@ -51,6 +51,45 @@ void Vertex::setPos(const float* pos, bool rotate) {
     }  
 }
 
+void Vertex::setVtxParameters(const TVector3& p1,
+			      const TVector3& p2,
+			      const double m) {
+
+  p1_.SetX(p1.X());
+  p1_.SetY(p1.Y());
+  p1_.SetZ(p1.Z());
+
+  p2_.SetX(p2.X());
+  p2_.SetY(p2.Y());
+  p2_.SetZ(p2.Z());
+  
+  p_ = p1_ + p2_;
+  
+  invM_  = m;
+
+}
+
+
+void Vertex::setVtxParameters(const TLorentzVector& p1,
+			      const TLorentzVector& p2){
+			      
+
+  p1_.SetX(p1.X());
+  p1_.SetY(p1.Y());
+  p1_.SetZ(p1.Z());
+
+  p2_.SetX(p2.X());
+  p2_.SetY(p2.Y());
+  p2_.SetZ(p2.Z());
+  
+  p_ = p1_ + p2_;
+  
+  invM_  = (p1 + p2).M();
+  
+}
+
+
+
 void Vertex::setVtxParameters(const std::vector<float>& parameters) { 
     parameters_ = parameters;
 

--- a/event/src/Vertex.cxx
+++ b/event/src/Vertex.cxx
@@ -72,20 +72,8 @@ void Vertex::setVtxParameters(const TVector3& p1,
 
 void Vertex::setVtxParameters(const TLorentzVector& p1,
 			      const TLorentzVector& p2){
-			      
-
-  p1_.SetX(p1.X());
-  p1_.SetY(p1.Y());
-  p1_.SetZ(p1.Z());
-
-  p2_.SetX(p2.X());
-  p2_.SetY(p2.Y());
-  p2_.SetZ(p2.Z());
   
-  p_ = p1_ + p2_;
-  
-  invM_  = (p1 + p2).M();
-  
+  this->setVtxParameters(p1.Vect(),p2.Vect(),(p1+p2).M());
 }
 
 

--- a/utils/include/TrackBiasingTool.h
+++ b/utils/include/TrackBiasingTool.h
@@ -7,14 +7,19 @@
 #include <random>
 #include <memory>
 
+
+
+
 //------------------//
 //    hpstr         //
 //------------------//
 
 #include "Track.h"
+#include "Vertex.h"
 
 class TFile;
 class TH1D;
+class TVector3;
 
 class TrackBiasingTool {
   
@@ -25,6 +30,12 @@ class TrackBiasingTool {
   
   double biasTrackP(const Track& track);
 
+  double getCorrection(const double& p,
+		       const double tanL,
+		       const int q);
+
+  void updateVertexWithBiasP(Vertex* vtx);
+   
   //Update the track P with a specific scale Factor
   void updateWithBiasP(Track& trk, double scaleFactor);
 

--- a/utils/src/TrackBiasingTool.cxx
+++ b/utils/src/TrackBiasingTool.cxx
@@ -27,9 +27,8 @@ TrackBiasingTool::TrackBiasingTool(const std::string& biasingfile,
 double TrackBiasingTool::getCorrection(const double& p,
 				       const double tanL,
 				       const int q) {
-
-  bool isTop = tanL > 0. ? true : false;
-  TH1D* bias_histo_ = isTop ?  eop_h_top_ : eop_h_bot_;
+  
+  TH1D* bias_histo_ = (tanL > 0.) ?  eop_h_top_ : eop_h_bot_;
   int binN = bias_histo_->GetXaxis()->FindBin(q);
   
   return bias_histo_->GetBinContent(binN);
@@ -40,11 +39,10 @@ double TrackBiasingTool::getCorrection(const double& p,
 double TrackBiasingTool::biasTrackP(const Track& trk) {
 
   double p = trk.getP();
-  bool isTop = trk.getTanLambda() > 0. ? true : false;
   double q = trk.getCharge();
-    
-  TH1D* bias_histo_ = isTop ?  eop_h_top_ : eop_h_bot_;
-    
+  
+  TH1D* bias_histo_ = (trk.getTanLambda() > 0.) ?  eop_h_top_ : eop_h_bot_;
+  
   int binN = bias_histo_->GetXaxis()->FindBin(q);
   if (debug_)
     std::cout<<"Track charge="<<q<<" bin="<<binN<<std::endl;

--- a/utils/src/TrackBiasingTool.cxx
+++ b/utils/src/TrackBiasingTool.cxx
@@ -1,6 +1,7 @@
 #include "TrackBiasingTool.h"
 #include "TFile.h"
 #include "TH1D.h"
+#include "TVector3.h"
 
 #include <stdexcept>
 
@@ -10,7 +11,7 @@ TrackBiasingTool::TrackBiasingTool(const std::string& biasingfile,
 
 
   biasingfile_ = std::make_shared<TFile>(biasingfile.c_str());
-
+  
   if (!biasingfile_)
     throw std::invalid_argument("Provided input biasing file doesn't exists");
   
@@ -22,10 +23,24 @@ TrackBiasingTool::TrackBiasingTool(const std::string& biasingfile,
 
 }
 
+
+double TrackBiasingTool::getCorrection(const double& p,
+				       const double tanL,
+				       const int q) {
+
+  bool isTop = tanL > 0. ? true : false;
+  TH1D* bias_histo_ = isTop ?  eop_h_top_ : eop_h_bot_;
+  int binN = bias_histo_->GetXaxis()->FindBin(q);
+  
+  return bias_histo_->GetBinContent(binN);
+
+}
+  
+
 double TrackBiasingTool::biasTrackP(const Track& trk) {
 
   double p = trk.getP();
-  double isTop = trk.getTanLambda() > 0. ? true : false;
+  bool isTop = trk.getTanLambda() > 0. ? true : false;
   double q = trk.getCharge();
     
   TH1D* bias_histo_ = isTop ?  eop_h_top_ : eop_h_bot_;
@@ -69,3 +84,29 @@ void TrackBiasingTool::updateWithBiasP(Track& trk, double scaleFactor) {
   trk.setMomentum(momentum);    
   
 }
+
+void TrackBiasingTool::updateVertexWithBiasP(Vertex* vtx) {
+
+  //Correct the vertex
+  double corr1 = getCorrection(vtx->getP1().Mag(), vtx->getP1Y(), -1); //ele
+  double corr2 = getCorrection(vtx->getP2().Mag(), vtx->getP2Y(), 1); //pos
+
+
+  TVector3 p1_corr, p2_corr;
+  double m_corr;
+
+  p1_corr.SetX(vtx->getP1X()*corr1);
+  p1_corr.SetY(vtx->getP1Y()*corr1);
+  p1_corr.SetZ(vtx->getP1Z()*corr1);
+  
+  p2_corr.SetX(vtx->getP2X()*corr2);
+  p2_corr.SetY(vtx->getP2Y()*corr2);
+  p2_corr.SetZ(vtx->getP2Z()*corr2);
+  
+  m_corr = vtx->getInvMass() * sqrt(corr1*corr2);
+  
+  vtx->setVtxParameters(p1_corr, p2_corr, m_corr);
+  
+}
+						
+


### PR DESCRIPTION
This commit adds the support for propagating the track biasing to vertices. 
Currently is only an approximation as the momentum magnitude correction from E/p is used to scale the momenta of the particles associated to a vertex as well as correct the invariant mass.

A better approach would be to do this in hps-java or refit the vertex in hpstr. 

