### PR TITLE
Clean-up memory

### DIFF
--- a/processors/src/FinalStateParticleProcessor.cxx
+++ b/processors/src/FinalStateParticleProcessor.cxx
@@ -148,6 +148,7 @@ bool FinalStateParticleProcessor::process(IEvent* ievent) {
                 // loop on j>i tracks
             }
             fsp->setTrack(track);
+            delete track;	    
         }   
          
         if (debug_ > 0) std::cout << "FinalStateParticleProcessor: Add Particle" << std::endl;

--- a/processors/src/VertexProcessor.cxx
+++ b/processors/src/VertexProcessor.cxx
@@ -195,11 +195,15 @@ bool VertexProcessor::process(IEvent* ievent) {
 
                     track->addHitLayer(hitLayer);
                     hits_.push_back(tracker_hit);
-                    rawSvthitsOn3d.clear();
+                    for (std::vector<RawSvtHit *>::iterator it = rawSvthitsOn3d.begin(); it != rawSvthitsOn3d.end(); ++it) {
+                      delete *it;
+                    }
+                    rawSvthitsOn3d.clear();		    
                     // loop on j>i tracks
                 }
                 track->setTrackerHitCount(nHits);
                 part->setTrack(track);
+		delete track;
             }
             //=============================================
             if (debug_ > 0) std::cout << "VertexProcessor: Add particle" << std::endl;


### PR DESCRIPTION
After running `valgrind`, a few areas in the event loop had memory that was not cleaned up, leading to high memory consumption for jobs (especially for large number of events). 