### PR TITLE
Adding a processor to make ROOTs or CSV files of flat tight selection quantities.

### DIFF
--- a/processors/config/nTupplizer_cfg.py
+++ b/processors/config/nTupplizer_cfg.py
@@ -1,0 +1,53 @@
+import HpstrConf
+import os
+import sys
+
+import baseConfig as base
+from baseConfig import bfield
+
+#base.parser.add_argument("-N", "--num", type=int, dest="num",
+#        help="The JOB number", metavar="num", default=0)
+
+options = base.parser.parse_args()
+
+# Use the input file to set the output file name
+inFilename  = options.inFilename[0]
+outFilename = '%s_nTup.root' % inFilename[:-5]
+
+print('Input file:  %s' % inFilename)
+print('Output file: %s' % outFilename)
+
+p = HpstrConf.Process()
+
+p.run_mode = 1
+#p.skip_events = options.skip_events
+p.max_events = options.nevents
+#p.max_events = 1000
+
+# Library containing processors
+p.add_library("libprocessors")
+
+###############################
+#          Processors         #
+###############################
+nTup = HpstrConf.Processor('nTup', 'NTupplizer')
+################################
+#   Processor Configuration   #
+###############################
+nTup.parameters["debug"] = 0 
+nTup.parameters["trkCollName"] = 'KalmanFullTracks'
+nTup.parameters["truthtrkCollName"] = 'Truth_KFTracks'
+nTup.parameters["fspCollName"] = 'FinalStateParticles_KF'
+nTup.parameters["mcCollName"] = 'MCParticle'
+nTup.parameters["sclusCollName"] = 'SiClusters'
+
+nTup.parameters["baselineFile"] = os.environ['HPSTR_BASE']+"/processors/dat/hps_14552_offline_baselines.dat"
+nTup.parameters["timeProfiles"] = os.environ['HPSTR_BASE'] + "/processors/dat/hpssvt_014393_database_svt_pulse_shapes_final.dat"
+nTup.parameters["outPutCsv"] = 1
+
+p.sequence = [nTup]
+
+p.input_files=[inFilename]
+p.output_files = [outFilename]
+
+p.printProcess()

--- a/processors/include/NTupplizer.h
+++ b/processors/include/NTupplizer.h
@@ -1,0 +1,160 @@
+#ifndef __NTUPPLIZER_H__
+#define __NTUPPLIZER_H__
+
+//-----------------//
+//   C++  StdLib   //
+//-----------------//
+#include <iostream>
+#include <string>
+
+//----------//
+//   ROOT   //
+//----------//
+#include "TClonesArray.h"
+
+//-----------//
+//   hpstr   //
+//-----------//
+#include "Processor.h"
+#include "BaseSelector.h"
+#include "Track.h"
+#include "Event.h"
+#include "TrackHistos.h"
+#include "TrackerHit.h"
+#include "Particle.h"
+#include "CalCluster.h"
+#include "MCParticle.h"
+#include "RawSvtHit.h"
+#include "ModuleMapper.h"
+
+
+#include "Processor.h"
+#include "TClonesArray.h"
+#include "TBranch.h"
+#include "TTree.h"
+#include "TFile.h"
+#include "TF1.h"
+#include "TGraphErrors.h"
+#include "TAxis.h"
+#include "TROOT.h"
+#include "TPad.h"
+#include "TCanvas.h"
+#include "TLegend.h"
+
+
+
+// Forward declarations
+class TTree; 
+
+/**
+ * @brief Insert description here.
+ * more details
+ */
+class NTupplizer : public Processor { 
+
+    public:
+        /**
+         * @brief Class constructor. 
+         *
+         * @param name Name for this instance of the class.
+         * @param process The Process class associated with Processor, provided
+         *                by the processing framework.
+         */
+        NTupplizer(const std::string& name, Process& process); 
+
+        /** Destructor */
+        ~NTupplizer(); 
+
+        /**
+         * @brief Configure the Ana Processor
+         * 
+         * @param parameters The configuration parameters
+         */
+        virtual void configure(const ParameterSet& parameters);
+
+        /**
+         * @brief Process the event and put new data products into it.
+         * 
+         * @param ievent The Event to process.
+         */
+        virtual bool process(IEvent* ievent);
+
+        /**
+         * @brief Callback for the Processor to take any necessary
+         *        action when the processing of events starts.
+         * 
+         * @param tree
+         */
+        virtual void initialize(TTree* tree);
+
+        /**
+         * @brief Callback for the Processor to take any necessary
+         *        action when the processing of events finishes.
+         */
+        virtual void finalize();
+
+	virtual void WriteRoot();
+        
+	virtual float str_to_float(std::string word);
+
+    private: 
+
+	TTree* tree_;
+
+	TH1F* Tracks_;
+	TH1F* Track_Lambda[12][14];	
+	TH1F* Track_Phi[12][14];	
+
+
+	std::ofstream csvFile_{nullptr};
+	int outPutCsv_{1};
+
+	int counter_{0};
+	int counter2_{0};
+        std::string baselineFile_;
+        std::string timeProfiles_;
+	ModuleMapper * mmapper_;
+	/** Container to hold all Track objects. */
+        std::vector<Track*>* tracks_{};
+        TBranch* btracks_{nullptr}; //!< description
+
+	std::vector<Particle*>* fsps_{};
+	TBranch* bfsps_{nullptr};
+
+	std::vector<CalCluster*>* eclusters_{}; 
+        TBranch* beclusters_{nullptr};
+
+	std::vector<TrackerHit*>* sclusters_{};
+        TBranch* bsclusters_{nullptr};
+		
+
+	float times1_[2][4][512][3];
+        float times2_[8][4][640][3];
+        float baseErr1_[2][4][512][12];
+        float baseErr2_[8][4][640][12];
+
+	TBranch* bevH_;
+        EventHeader * evH_;
+
+	std::vector<MCParticle*>* mcpart_{};
+	TBranch* bmcpart_{nullptr};
+
+        //std::vector<Track*>* trtracks_{};
+	//TBranch* btrtracks_{nullptr}; //!< description
+
+        std::string trkCollName_{"KalmanFullTracks"}; //!< Track Collection name
+	std::string fspCollName_{"FinalStateParticles_KF"};
+	std::string eclusCollName_{"RecoEcalClusters"}; //!< description
+	std::string mcCollName_{"MCParticle"};
+	std::string sclusCollName_{"SiClusters"};
+	//std::string num_{"0"};
+
+	//std::string truthtrkCollName_{"Truth_KFTracks"};
+        
+	int readout_{0};
+	
+	int debug_{0}; //!< debug level
+
+};
+
+#endif

--- a/processors/include/NTupplizer.h
+++ b/processors/include/NTupplizer.h
@@ -104,7 +104,20 @@ class NTupplizer : public Processor {
 	TH1F* Tracks_;
 	TH1F* Track_Lambda[12][14];	
 	TH1F* Track_Phi[12][14];	
-
+	TH1F* Track_D0[12];
+	TH1F* Track_PHI[12];
+	TH1F* Track_OMEGA[12];
+	TH1F* Track_TANLAMBDA[12];
+	TH1F* Track_Z0[12];
+	TH1F* Track_CHI2[12];
+	TH1F* Track_NDF[12];
+	TH1F* Track_TIME[12];
+	TH1F* Track_POSX[12];
+	TH1F* Track_POSY[12];
+	TH1F* Track_POSZ[12];
+	TH1F* Track_MOMX[12];
+	TH1F* Track_MOMY[12];
+	TH1F* Track_MOMZ[12];
 
 	std::ofstream csvFile_{nullptr};
 	int outPutCsv_{1};

--- a/processors/src/NTupplizer.cxx
+++ b/processors/src/NTupplizer.cxx
@@ -1,0 +1,142 @@
+#include "NTupplizer.h"
+#include <iomanip>
+#include <set>
+#include "utilities.h"
+
+NTupplizer::NTupplizer(const std::string& name, Process& process)
+	: Processor(name, process) { 
+	mmapper_ = new ModuleMapper();
+	}
+
+NTupplizer::~NTupplizer() { 
+}
+
+void NTupplizer::configure(const ParameterSet& parameters) {
+
+	std::cout << "Configuring TrackPerformance" << std::endl;
+	try
+	{
+		debug_                = parameters.getInteger("debug",debug_);
+		trkCollName_          = parameters.getString("trkCollName",trkCollName_);
+		fspCollName_	      = parameters.getString("fspCollName",fspCollName_);
+		eclusCollName_	      = parameters.getString("eclusCollName",eclusCollName_);
+		sclusCollName_	      = parameters.getString("sclusCollName",sclusCollName_);
+		baselineFile_ 	      = parameters.getString("baselineFile");
+        	timeProfiles_ 	      = parameters.getString("timeProfiles");
+		outPutCsv_	      = parameters.getInteger("outPutCsv");
+	}
+	catch (std::runtime_error& error)
+	{
+		std::cout << error.what() << std::endl;
+	}
+}
+
+void NTupplizer::initialize(TTree* tree) {
+	if(outPutCsv_==1){
+		csvFile_=std::ofstream("outputCSV.csv");
+		csvFile_<<"EventNum,TrackNo";
+		for(int i = 0; i<12;i++){
+			for(int j = 0; j<14;j++){
+				csvFile_<<",track_"+std::to_string(i)+"_lay_"+std::to_string(j)+"_lambkink";
+				csvFile_<<",track_"+std::to_string(i)+"_lay_"+std::to_string(j)+"_phikink";
+			}
+		}
+		csvFile_<<"\n";
+	}
+	std::cout<<"I GOT HERE 3"<<std::endl;
+	tree_= tree;
+	tree_->SetBranchAddress(trkCollName_.c_str(),&tracks_, &btracks_); 
+	tree_->SetBranchAddress(fspCollName_.c_str(),&fsps_, &bfsps_);
+	tree_->SetBranchAddress(eclusCollName_.c_str(),&eclusters_,&beclusters_);
+	tree_->SetBranchAddress(sclusCollName_.c_str(),&sclusters_,&bsclusters_);
+    	tree_->SetBranchAddress("EventHeader",&evH_,&bevH_);
+	Tracks_ = new TH1F("Tracks","Tracks",10,0,10);
+	for(int i=0;i<12;i++){
+		for(int j=0;j<14;j++){
+			std::string title1="track_"+std::to_string(i)+"_layer_"+std::to_string(j)+"_lamdba";
+			std::string title2="track_"+std::to_string(i)+"_layer_"+std::to_string(j)+"_phi";
+			Track_Lambda[i][j]=new TH1F(title1.c_str(),"Tracks",100,-1.0,1.0);
+			Track_Phi[i][j]=new TH1F(title2.c_str(),"Tracks",100,-1.0,1.0);
+		}
+	}	
+	return;
+}
+
+bool NTupplizer::process(IEvent* ievent) {
+	int STRIPNUM = 0;
+	int STRIP = -1;
+	long eventTime = evH_->getEventTime();
+	int eventNum = evH_->getEventNumber();
+    	int trigPhase = (int)((eventTime%24)/4);
+	//std::cout<<"I GOT HERE 1"<<std::endl;
+	//HERE IS WHERE WE PUT ALL THE CSV TITLES. FIRST UP IS ALL THE LAMBDA KINKS FOR 12 TRACKS IN ORDER
+	std::string helper=std::to_string(eventNum)+","+std::to_string(tracks_->size());
+	Tracks_->Fill(tracks_->size());
+	//I AM GOING TO ORDER THE TRACKS THEIR ORDER; ONE MAY USE ERROR TO DO A DIFFERENT ORDERING, AND GOING TO CAP AT 12
+	for (int itrack = 0; itrack < 12; ++itrack) {
+		Track* track{nullptr};	
+		if(itrack<tracks_->size()){	
+			track = tracks_->at(itrack);
+			for(int j=0;j<14;j++){
+				helper+=","+std::to_string(track->getLambdaKink(j));
+				helper+=","+std::to_string(track->getPhiKink(j));
+				Track_Lambda[itrack][j]->Fill(track->getLambdaKink(j));	
+				Track_Phi[itrack][j]->Fill(track->getPhiKink(j));	
+			}
+		}else{
+			for(int j=0;j<14;j++){
+				helper+=","+std::to_string(-1000.0);
+				helper+=","+std::to_string(-1000.0);
+				Track_Lambda[itrack][j]->Fill(-1000.0);	
+				Track_Phi[itrack][j]->Fill(-1000.0);	
+			}	
+		}		
+	}
+	helper+="\n";
+	if(outPutCsv_=1){
+		csvFile_<<helper;
+	}
+	return true;
+}
+
+
+float NTupplizer::str_to_float(std::string token){
+    std::string top1=token.substr(0,token.find("."));
+    const char *top=top1.c_str();
+    std::string bot1=token.substr(token.find(".")+1);
+    const char *bottom=bot1.c_str();
+    float base = 0.0;
+    for(int J=0;J<std::strlen(top);J++){
+        base+=((float)((int)top[J]-48))*pow(10.0,(float)(std::strlen(top)-J-1));
+    }
+    for(int J=0;J<std::strlen(bottom);J++){
+        base+=((float)((int)bottom[J]-48))*pow(10.0,-1*((float)J+1.0));
+    } 
+    return base;
+}
+
+void NTupplizer::WriteRoot() { 
+	if(outPutCsv_==1){
+		csvFile_.close();
+	}
+	if(outPutCsv_==0){
+		TFile *outputFile;
+		outputFile = new TFile("outputRoot.root","RECREATE");
+		Tracks_->Write();
+		for(int i=0;i<12;i++){
+			for(int j=0;j<14;j++){
+				Track_Lambda[i][j]->Write();
+				Track_Phi[i][j]->Write();
+			}
+		}
+		outputFile->Close();
+	}
+	return;
+}
+
+void NTupplizer::finalize() { 
+	WriteRoot();
+	return;
+}
+
+DECLARE_PROCESSOR(NTupplizer); 

--- a/processors/src/NTupplizer.cxx
+++ b/processors/src/NTupplizer.cxx
@@ -39,6 +39,20 @@ void NTupplizer::initialize(TTree* tree) {
 			for(int j = 0; j<14;j++){
 				csvFile_<<",track_"+std::to_string(i)+"_lay_"+std::to_string(j)+"_lambkink";
 				csvFile_<<",track_"+std::to_string(i)+"_lay_"+std::to_string(j)+"_phikink";
+				csvFile_<<",track_"+std::to_string(i)+"_d0";
+				csvFile_<<",track_"+std::to_string(i)+"_phi0";
+				csvFile_<<",track_"+std::to_string(i)+"_omega";
+				csvFile_<<",track_"+std::to_string(i)+"_tanlambda";
+				csvFile_<<",tracl_"+std::to_string(i)+"_z0";
+				csvFile_<<",tracl_"+std::to_string(i)+"_chi2";
+				csvFile_<<",tracl_"+std::to_string(i)+"_ndf";
+				csvFile_<<",tracl_"+std::to_string(i)+"_time";
+				csvFile_<<",tracl_"+std::to_string(i)+"_x";
+				csvFile_<<",tracl_"+std::to_string(i)+"_y";
+				csvFile_<<",tracl_"+std::to_string(i)+"_z";
+				csvFile_<<",tracl_"+std::to_string(i)+"_px";
+				csvFile_<<",tracl_"+std::to_string(i)+"_py";
+				csvFile_<<",tracl_"+std::to_string(i)+"_pz";
 			}
 		}
 		csvFile_<<"\n";
@@ -58,6 +72,20 @@ void NTupplizer::initialize(TTree* tree) {
 			Track_Lambda[i][j]=new TH1F(title1.c_str(),"Tracks",100,-1.0,1.0);
 			Track_Phi[i][j]=new TH1F(title2.c_str(),"Tracks",100,-1.0,1.0);
 		}
+		Track_D0[i]=new TH1F();
+		Track_PHI[i]=new TH1F();
+		Track_OMEGA[i]=new TH1F();
+		Track_TANLAMBDA[i]=new TH1F();
+		Track_Z0[i]=new TH1F();
+		Track_CHI2[i]=new TH1F();
+		Track_NDF[i]=new TH1F();
+		Track_TIME[i]=new TH1F();
+		Track_POSX[i]=new TH1F();
+		Track_POSY[i]=new TH1F();
+		Track_POSZ[i]=new TH1F();
+		Track_MOMX[i]=new TH1F();
+		Track_MOMY[i]=new TH1F();
+		Track_MOMZ[i]=new TH1F();
 	}	
 	return;
 }
@@ -80,16 +108,65 @@ bool NTupplizer::process(IEvent* ievent) {
 			for(int j=0;j<14;j++){
 				helper+=","+std::to_string(track->getLambdaKink(j));
 				helper+=","+std::to_string(track->getPhiKink(j));
+
 				Track_Lambda[itrack][j]->Fill(track->getLambdaKink(j));	
 				Track_Phi[itrack][j]->Fill(track->getPhiKink(j));	
 			}
+			helper+=","+std::to_string(track->getD0());
+			helper+=","+std::to_string(track->getPhi());
+			helper+=","+std::to_string(track->getOmega());
+			helper+=","+std::to_string(track->getTanLambda());
+			helper+=","+std::to_string(track->getZ0());
+			helper+=","+std::to_string(track->getChi2());
+			helper+=","+std::to_string(track->getNdf());
+			helper+=","+std::to_string(track->getTrackTime());
+			std::vector<double> position=track->getPosition();
+			helper+=","+std::to_string(position[0]);
+			helper+=","+std::to_string(position[1]);
+			helper+=","+std::to_string(position[2]);
+			std::vector<double> momentum=track->getMomentum();
+			helper+=","+std::to_string(momentum[0]);
+			helper+=","+std::to_string(momentum[1]);
+			helper+=","+std::to_string(momentum[2]);
+
+			Track_D0[itrack]->Fill(track->getD0());
+			Track_PHI[itrack]->Fill(track->getPhi());
+			Track_OMEGA[itrack]->Fill(track->getOmega());
+			Track_TANLAMBDA[itrack]->Fill(track->getTanLambda());
+			Track_Z0[itrack]->Fill(track->getZ0());
+			Track_CHI2[itrack]->Fill(track->getChi2());
+			Track_NDF[itrack]->Fill(track->getNdf());
+			Track_TIME[itrack]->Fill(track->getTrackTime());
+			Track_POSX[itrack]->Fill(position[0]);
+			Track_POSY[itrack]->Fill(position[1]);
+			Track_POSZ[itrack]->Fill(position[2]);
+			Track_MOMX[itrack]->Fill(momentum[0]);
+			Track_MOMY[itrack]->Fill(momentum[1]);
+			Track_MOMZ[itrack]->Fill(momentum[2]);
 		}else{
-			for(int j=0;j<14;j++){
-				helper+=","+std::to_string(-1000.0);
+			for(int j=0;j<14;j++){	
 				helper+=","+std::to_string(-1000.0);
 				Track_Lambda[itrack][j]->Fill(-1000.0);	
-				Track_Phi[itrack][j]->Fill(-1000.0);	
-			}	
+				Track_Phi[itrack][j]->Fill(-1000.0);
+			}
+			//HERE 14 IS THE NUMBER OF VARIABLES THAT ARE BLANK AND ARENT THE KINKS
+			for(int I=0;I<14;I++){
+				helper+=","+std::to_string(-1000.0);
+			}
+			Track_D0[itrack]->Fill(-1000.0);
+			Track_PHI[itrack]->Fill(-1000.0);
+			Track_OMEGA[itrack]->Fill(-1000.0);
+			Track_TANLAMBDA[itrack]->Fill(-1000.0);
+			Track_Z0[itrack]->Fill(-1000.0);
+			Track_CHI2[itrack]->Fill(-1000.0);
+			Track_NDF[itrack]->Fill(-1000.0);
+			Track_TIME[itrack]->Fill(-1000.0);
+			Track_POSX[itrack]->Fill(-1000.0);
+			Track_POSY[itrack]->Fill(-1000.0);
+			Track_POSZ[itrack]->Fill(-1000.0);
+			Track_MOMX[itrack]->Fill(-1000.0);
+			Track_MOMY[itrack]->Fill(-1000.0);
+			Track_MOMZ[itrack]->Fill(-1000.0);
 		}		
 	}
 	helper+="\n";
@@ -128,6 +205,20 @@ void NTupplizer::WriteRoot() {
 				Track_Lambda[i][j]->Write();
 				Track_Phi[i][j]->Write();
 			}
+			Track_D0[i]->Write();
+			Track_PHI[i]->Write();
+			Track_OMEGA[i]->Write();
+			Track_TANLAMBDA[i]->Write();
+			Track_Z0[i]->Write();
+			Track_CHI2[i]->Write();
+			Track_NDF[i]->Write();
+			Track_TIME[i]->Write();
+			Track_POSX[i]->Write();
+			Track_POSY[i]->Write();
+			Track_POSZ[i]->Write();
+			Track_MOMX[i]->Write();
+			Track_MOMY[i]->Write();
+			Track_MOMZ[i]->Write();
 		}
 		outputFile->Close();
 	}


### PR DESCRIPTION
I am adding NTupplizer.cxx, NTupplizer.h, and nTupplizer_cfg.py to hpstr. These are meant to take the output of some kalTuple_cfg.py or simple tupplizer and flatten the data further, retaining only information relevant for a ROOT TMVA or python csv analysis. Right now it just includes the track number, and for the first 12 tracks 14 quantities denoted as the lamda or phi kinks. These are probably the most useful qauntities to retain for TMVA. It has a setting wherein it can variably output a root or csv file depending on what is enabled in nTupplizer_cfg.py. The csv is large, but maneagable for any python analysis.