### PR TITLE
Cleanup raw hit memory

### DIFF
--- a/processors/src/VertexProcessor.cxx
+++ b/processors/src/VertexProcessor.cxx
@@ -210,7 +210,10 @@ bool VertexProcessor::process(IEvent* ievent) {
 
 			track->addHitLayer(hitLayer);
 			hits_.push_back(tracker_hit);
-	                rawSvthitsOn3d.clear();
+                        for (std::vector<RawSvtHit *>::iterator it = rawSvthitsOn3d.begin(); it != rawSvthitsOn3d.end(); ++it) {
+                          delete *it;
+                        }
+                        rawSvthitsOn3d.clear();	
 
                     } // Loop over hits on track
 


### PR DESCRIPTION
Fix was introduced in: https://github.com/JeffersonLab/hpstr/pull/202 

But got lost when transitioning the code allow flexibility to run without hit collections.