### PR TITLE
Reduce hit layer by one when using hit pattern

### DIFF
--- a/processors/src/TrackingProcessor.cxx
+++ b/processors/src/TrackingProcessor.cxx
@@ -185,7 +185,7 @@ bool TrackingProcessor::process(IEvent* ievent) {
 	    auto hitPattern = lc_track->getSubdetectorHitNumbers();
 	    for( int h=0; h<hitPattern.size(); h++){
 		if( hitPattern[h]>0 ){
-		    track->addHitLayer(h+1);
+		    track->addHitLayer(h);
 		    nHits++;
 		}
 	    }

--- a/processors/src/VertexProcessor.cxx
+++ b/processors/src/VertexProcessor.cxx
@@ -162,7 +162,7 @@ bool VertexProcessor::process(IEvent* ievent) {
                     auto hitPattern = lc_track->getSubdetectorHitNumbers();
                     for( int h=0; h<hitPattern.size(); h++){
                         if( hitPattern[h]>0 ){
-                            track->addHitLayer(h+1);
+                            track->addHitLayer(h);
                             nHits++;
                         }
                     }


### PR DESCRIPTION
Such that, files produced with and without hit collections have consistent numbering schemes with with 0 -> 13