### PR TITLE
remove dependence on VTPBank collection

### DIFF
--- a/processors/config/recoTuple_cfg.py
+++ b/processors/config/recoTuple_cfg.py
@@ -55,8 +55,8 @@ header.parameters["debug"] = 0
 header.parameters["headCollRoot"] = "EventHeader"
 header.parameters["trigCollLcio"] = "TriggerBank"
 header.parameters["rfCollLcio"] = "RFHits"
-header.parameters["vtpCollLcio"] = "VTPBank"
-header.parameters["vtpCollRoot"] = "VTPBank"
+#header.parameters["vtpCollLcio"] = "VTPBank"
+#header.parameters["vtpCollRoot"] = "VTPBank"
 header.parameters["tsCollLcio"] = "TSBank"
 header.parameters["tsCollRoot"] = "TSBank"
 

--- a/processors/config/recoTuple_noHitColl_cfg.py
+++ b/processors/config/recoTuple_noHitColl_cfg.py
@@ -55,8 +55,8 @@ header.parameters["debug"] = 0
 header.parameters["headCollRoot"] = "EventHeader"
 header.parameters["trigCollLcio"] = "TriggerBank"
 header.parameters["rfCollLcio"] = "RFHits"
-header.parameters["vtpCollLcio"] = "VTPBank"
-header.parameters["vtpCollRoot"] = "VTPBank"
+#header.parameters["vtpCollLcio"] = "VTPBank"
+#header.parameters["vtpCollRoot"] = "VTPBank"
 header.parameters["tsCollLcio"] = "TSBank"
 header.parameters["tsCollRoot"] = "TSBank"
 

--- a/processors/include/EventProcessor.h
+++ b/processors/include/EventProcessor.h
@@ -99,8 +99,8 @@ class EventProcessor : public Processor {
 
         /** Containers for vtp data */
         VTPData* vtpData{nullptr};
-        std::string vtpCollLcio_{"VTPBank"}; //!< description
-        std::string vtpCollRoot_{"VTPBank"}; //!< description
+        std::string vtpCollLcio_{""}; //!< description
+        std::string vtpCollRoot_{""}; //!< description
 
         /** Containers for ts data */
         TSData* tsData{nullptr};
@@ -117,6 +117,7 @@ class EventProcessor : public Processor {
         std::map<int,std::vector<int >> run_evts_map_; //!< description
 
         int debug_{0}; //!< Debug Level
+	int year_{2021};
 
 }; // EventProcessor
 


### PR DESCRIPTION
The VTPBank collection is not used for both MC and data. Currently, the collection does not exist in MC and will be removed for data in future passes. However, the EventProcessor currently defaults to querying the trigger information from the EventHeader (2016 style) if the VTPBank collection cannot be found. For 2019 and 2021, we would like to instead use the TSBank collection to get the trigger information.

To ensure that the correct collection is used for the trigger information, I have added a ```year_``` variable to the EventProcessor instead of having some faulty automatic determination. ```year_``` is set to 2021 per default but can be configured to any other year.