### PR TITLE
adding information of origin MC particle

### DIFF
--- a/event/include/MCParticle.h
+++ b/event/include/MCParticle.h
@@ -74,6 +74,13 @@ class MCParticle : public TObject {
         void setMomPDG(const int momPDG) { momPDG_ = momPDG; }; 
 
         /**
+         * Set the PDG ID of the origin particle.
+         *
+         * @param momPDG The PDG ID of the origin particle
+         */
+        void setOriginPDG(const int originPDG) {originPDG_ = originPDG; };
+
+        /**
          * Set the generator status of the particle.
          *
          * @param gen_ MCParticle generator status
@@ -150,7 +157,10 @@ class MCParticle : public TObject {
         int getID() const { return id_; }; 
         
         /** @return The particle ID of the mother. */
-        int getMomPDG() const { return momPDG_; }; 
+        int getMomPDG() const { return momPDG_; };
+
+        /** @return The particle ID of the origin particle */
+        int getOriginPDG() const { return originPDG_; };
         
         /** @return The particle generator status. */
         int getGenStatus() const { return gen_; }; 
@@ -201,8 +211,11 @@ class MCParticle : public TObject {
         /** The PDG ID of this particle */
         int pdg_{-9999}; 
 
-        /** The PDG ID of this particle */
+        /** The PDG ID of the mother particle */
         int momPDG_{-9999}; 
+
+        /** The PDG ID of the origin particle */
+        int originPDG_{-9999};
 
         /** The generator status of the particle */ 
         int gen_{-9999}; 

--- a/processors/src/MCParticleProcessor.cxx
+++ b/processors/src/MCParticleProcessor.cxx
@@ -98,10 +98,19 @@ bool MCParticleProcessor::process(IEvent* ievent) {
         // Set the LCIO id of the particle
         particle->setID(lc_particle->id());    
 
-        // Set the PDG of the particle
+        // Set the PDG of the mother and origin particle
         std::vector<EVENT::MCParticle*> parentVec = lc_particle->getParents();
-        if(parentVec.size() > 0) particle->setMomPDG(parentVec.at(parentVec.size()-1)->getPDG());    
-
+        if(parentVec.size() > 0) {
+            particle->setMomPDG(parentVec.at(parentVec.size()-1)->getPDG());
+            while (parentVec.size() > 0) {
+                if (parentVec.at(parentVec.size()-1)->getPDG() == 622 || parentVec.at(parentVec.size()-1)->getPDG() == 623) {
+                    particle->setOriginPDG(parentVec.at(parentVec.size()-1)->getPDG());
+                    break;
+                }
+                parentVec = parentVec.at(parentVec.size()-1)->getParents();
+            }
+        }
+        
         // Set the generator status of the particle
         particle->setGenStatus(lc_particle->getGeneratorStatus());    
 


### PR DESCRIPTION
The proposed changes will enable us to keep track if particles originate from the A' vertex (or other) even if they undergo secondary processes (brems, conversions, ...) afterwards.

Since this changes the structure of the MCParticle class, we should discuss when we want to merge this before we do so.