### PR TITLE
Fix issue with cmake not completing on AlmaLinux 9

### DIFF
--- a/cmake/Modules/MacroModule.cmake
+++ b/cmake/Modules/MacroModule.cmake
@@ -99,7 +99,7 @@ macro(MODULE)
     add_library(${MODULE_NAME} SHARED ${sources} ${MODULE_EXTRA_SOURCES})
    
     # add link libs
-    target_link_libraries(${MODULE_NAME} ${MODULE_LIBRARIES} ${MODULE_EXTRA_LINK_LIBRARIES})
+    target_link_libraries(${MODULE_NAME} PUBLIC ${MODULE_LIBRARIES} ${MODULE_EXTRA_LINK_LIBRARIES})
   
     # install the library
     install(TARGETS ${MODULE_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)


### PR DESCRIPTION
Simple fix on the macro: always state if libraries are PUBLIC or PRIVATE.
This fixes the issue with running cmake on AlmaLinux 9 at Jlab.
