### PR TITLE
Adding third track variables

### DIFF
--- a/processors/include/PreselectAndCategorize2021.h
+++ b/processors/include/PreselectAndCategorize2021.h
@@ -9,6 +9,8 @@
 
 #include <sstream>
 #include <string>
+#include <set>
+
 
 #include "Math/Vector4D.h"
 #include "PreselectAndCategorize.h"
@@ -17,6 +19,7 @@
 #include "TrackBiasingTool.h"
 #include "TrackSmearingTool.h"
 #include "TruthMatchingUtils.h"
+#include "TrackTools.h"
 
 class PreselectAndCategorize2021 : public PreselectAndCategorize {
   public:
@@ -58,6 +61,14 @@ class PreselectAndCategorize2021 : public PreselectAndCategorize {
     //   p_recoil = p_beam - p_ele - p_pos
     // and theta_R is the angle between p_recoil and the beam direction.
     double calculate_theta_R(const TVector3& ele_mom, const TVector3& pos_mom) const;
+
+    bool saveAllTracks_{false}; // if true, save all tracks in the event
+    bool calcMultiTrackVars_{false}; // if true, calculate event-level variables (min_dTanlambda, etc.)
+
+    Track* createInferredTrack(Vertex* vtx, Track* ele_track, Track* pos_track);
+
+    bool isQualityTrack(Track* trk, const Particle& pos) const;
+    void calculatePairwiseQuantities(const std::vector<Track*>& all_tracks,  Particle& ele, Particle& pos);
 };
 
 #endif  //__PRESELECT_AND_CATEGORIZE_2021_H__

--- a/processors/include/PreselectAndCategorize2021.h
+++ b/processors/include/PreselectAndCategorize2021.h
@@ -65,7 +65,7 @@ class PreselectAndCategorize2021 : public PreselectAndCategorize {
     bool saveAllTracks_{false}; // if true, save all tracks in the event
     bool calcMultiTrackVars_{false}; // if true, calculate event-level variables (min_dTanlambda, etc.)
 
-    Track* createInferredTrack(Vertex* vtx, Track* ele_track, Track* pos_track);
+    Track createInferredTrack(Vertex* vtx, Track* ele_track, Track* pos_track);
 
     bool isQualityTrack(Track* trk, const Particle& pos) const;
     void calculatePairwiseQuantities(const std::vector<Track*>& all_tracks,  Particle& ele, Particle& pos);

--- a/processors/include/TrackTools.h
+++ b/processors/include/TrackTools.h
@@ -1,0 +1,188 @@
+#ifndef _TRACKTOOLS_
+#define _TRACKTOOLS_
+
+
+#include <EVENT/LCCollection.h>
+#include <EVENT/Track.h>
+#include <EVENT/ReconstructedParticle.h>
+#include <EVENT/Vertex.h>
+#include <EVENT/TrackerHit.h>
+#include <EVENT/TrackState.h>
+#include <EVENT/TrackerRawData.h>
+#include <EVENT/CalorimeterHit.h>
+#include <EVENT/Cluster.h>
+#include <IMPL/CalorimeterHitImpl.h>
+#include <IMPL/LCGenericObjectImpl.h>
+#include <IMPL/TrackerHitImpl.h>
+#include <IMPL/ClusterImpl.h>
+#include <UTIL/LCRelationNavigator.h>
+#include <UTIL/BitField64.h>
+
+
+#include <vector>
+#include <cmath>
+#include <array>
+#include <iostream>
+#include <fstream>
+
+//-----------//
+//   hpstr   //
+//-----------//
+#include "Collections.h"
+#include "Processor.h"
+#include "Particle.h"
+#include "Track.h"
+#include "Event.h"
+#include "Vertex.h"
+#include "TrackerHit.h"
+
+
+//-----------//
+//   ROOT    //
+//-----------//
+#include "TRefArray.h"
+#include "TMatrixD.h"
+
+namespace TrackTools {
+
+
+    /**
+     * @brief Normalize angle to [-π, π]
+     * 
+     * @param angle Input angle (radians)
+     * @return double Normalized angle
+     */
+    float normalizeAngle(float angle);
+
+    /**
+     * @brief Extract track parameter covariance matrix from Track object
+     * 
+     * @param track Input track
+     * @return TMatrixD 5x5 covariance matrix [d0, phi0, omega, z0, tanLambda]
+     */
+    TMatrixD getTrackCovariance(Track* track);
+
+    /**
+     * @brief Extract vertex position covariance from Vertex object
+     * 
+     * @param vtx Input vertex
+     * @return TMatrixD 3x3 covariance matrix [x, y, z]
+     */
+    TMatrixD getVertexCovariance(Vertex* vtx);
+
+    /**
+     * @brief Calculate momentum covariance from track parameter covariance
+     * 
+     * Given track momentum components (px, py, pz) and track parameters,
+     * propagate the track parameter covariance to momentum covariance.
+     * 
+     * @param px
+     * @param py
+     * @param pz
+     * @param phi0
+     * @param omega
+     * @param tanLambda
+     * @param covTrack 5x5 track parameter covariance matrix
+     * @return TMatrixD 3x3 momentum covariance matrix
+     */
+    TMatrixD momentumCovarianceFromTrack(
+        double px, double py, double pz,
+        double phi0, double omega, double tanLambda,
+        const TMatrixD& covTrack);
+
+    /**
+     * @brief Calculate momentum covariance from Track object
+     * 
+     * @param track
+     * @return TMatrixD 3x3 momentum covariance matrix
+     */
+    TMatrixD momentumCovarianceFromTrack(Track* track);
+
+
+    /**
+     * @brief Calculate track parameters at target from position and momentum
+     * 
+     * Coordinate system:
+     *   - x, z: transverse plane
+     *   - y: beam direction
+     * 
+     * @param x_vtx
+     * @param y_vtx
+     * @param z_vtx
+     * @param px
+     * @param py
+     * @param pz
+     * @param Q
+     * @param cB
+     * @param targetPos y-coordinate of "new" pivot point (mm)
+     * @return Track parameters [d0, phi0, omega, z0, tanLambda]
+     */
+    std::vector<float> calculateTrackParameters(
+            float x_vtx, float y_vtx, float z_vtx,
+            float px, float py, float pz, float Q,
+            float cB, float targetPos);
+
+    /**
+     * @brief Analytical Jacobian: d[d0,phi0,omega,z0,tanLambda]/d[x,y,z,px,py,pz]
+     * 
+     * @param x_vtx
+     * @param y_vtx
+     * @param z_vtx
+     * @param px
+     * @param py
+     * @param pz
+     * @param Q
+     * @param cB
+     * @param targetPos y-coordinate of pivot point
+     * @return TMatrixD 5x6 Jacobian matrix
+     */
+    TMatrixD trackParametersJacobian(
+        float x_vtx, float y_vtx, float z_vtx,
+        float px, float py, float pz, float Q,
+        float cB, float targetPos);
+
+    
+    /**
+    * @brief Calculate track parameter covariance from momentum, position
+    * 
+    * Given vertex position, momentum, and their covariances, propagate
+    * to track parameter covariance using the Jacobian.
+    * 
+    * @param x_vtx, y_vtx, z_vtx
+    * @param px, py, pz
+    * @param covVertex
+    * @param covMomentum
+    * @param Q
+    * @param cB
+    * @param targetPos
+    * @return TMatrixD 5x5 track parameter covariance matrix
+    */
+    TMatrixD calculateTrackCovariance(
+        float x_vtx, float y_vtx, float z_vtx,
+        float px, float py, float pz,
+        const TMatrixD& covVertex,
+        const TMatrixD& covMomentum,
+        float Q, float cB, float targetPos);
+
+
+        /**
+        * @brief Build combined 6x6 covariance matrix [x,y,z,px,py,pz]
+        * 
+        * @param covVertex
+        * @param covMomentum
+        * @param covCross
+        * @return TMatrixD 6x6 combined covariance
+        */
+        TMatrixD buildCombinedCovariance(
+            const TMatrixD& covVertex,
+            const TMatrixD& covMomentum,
+            const TMatrixD* covCross = nullptr);
+
+        TMatrixD numericalJacobian(
+            float x_vtx, float y_vtx, float z_vtx,
+            float px, float py, float pz,
+            float Q, float cB, float targetPos);
+
+}
+
+#endif //TRACKTOOLS

--- a/processors/src/PreselectAndCategorize2021.cxx
+++ b/processors/src/PreselectAndCategorize2021.cxx
@@ -184,9 +184,9 @@ double PreselectAndCategorize2021::calculate_theta_R(const TVector3& ele_mom, co
     return std::acos(cos_theta) * 1000.0;
 }
 
-Track* PreselectAndCategorize2021::createInferredTrack(Vertex* vtx, Track* ele_track, Track* pos_track) {
+Track PreselectAndCategorize2021::createInferredTrack(Vertex* vtx, Track* ele_track, Track* pos_track) {
 
-    Track* inferredTrack = new Track();
+    Track inferredTrack;
 
     TVector3 ele_mom(ele_track->getMomentum()[0], ele_track->getMomentum()[1], ele_track->getMomentum()[2]);
     TVector3 pos_mom(pos_track->getMomentum()[0], pos_track->getMomentum()[1], pos_track->getMomentum()[2]);
@@ -214,7 +214,7 @@ Track* PreselectAndCategorize2021::createInferredTrack(Vertex* vtx, Track* ele_t
         vtx->getX(), vtx->getY(), vtx->getZ(),
         recoil_px, recoil_py, recoil_pz, inferredCharge, cB, target_pos);
 
-    inferredTrack->setTrackParameters(
+    inferredTrack.setTrackParameters(
         params[0],  // d0
         params[1],  // phi0
         params[2],  // omega
@@ -247,10 +247,10 @@ Track* PreselectAndCategorize2021::createInferredTrack(Vertex* vtx, Track* ele_t
         }
     }
     
-    inferredTrack->setCov(covArray);
+    inferredTrack.setCov(covArray);
     
     // Set momentum
-    inferredTrack->setMomentum(recoil_px, recoil_py, recoil_pz);
+    inferredTrack.setMomentum(recoil_px, recoil_py, recoil_pz);
 
     return inferredTrack;
 
@@ -1065,7 +1065,7 @@ bool PreselectAndCategorize2021::process(IEvent*) {
     bus_.set("epem_opening_angle", ele_mom.Angle(pos_mom));
     bus_.set("recoil_theta", calculate_theta_R(ele_mom, pos_mom));
 
-    Track thirdTrack = *dynamic_cast<Track*>(createInferredTrack(&vtx, &ele_trk, &pos_trk));
+    Track thirdTrack = createInferredTrack(&vtx, &ele_trk, &pos_trk);
 
     // calculate target projection and its significance
     if (not v0proj_fits_.empty()) {

--- a/processors/src/PreselectAndCategorize2021.cxx
+++ b/processors/src/PreselectAndCategorize2021.cxx
@@ -50,6 +50,12 @@ void PreselectAndCategorize2021::configure(const ParameterSet& parameters) {
     scaleCorrVariable_ = parameters.getString("scaleCorrVariable", "");
     applyMeanCorr_     = parameters.getInteger("applyMeanCorr", 0) != 0;
 
+    // Save all tracks in the event
+    saveAllTracks_ = parameters.getInteger("saveAllTracks", 0) != 0;
+    // Calculate variables that depend on multiple tracks
+    calcMultiTrackVars_ = parameters.getInteger("calcMultiTrackVars", 0) != 0;
+
+
     std::string smearingFile = !smearingCfgFile.empty() ? smearingCfgFile : pSmearingFile;
 
     if (not smearingFile.empty()) {
@@ -178,6 +184,240 @@ double PreselectAndCategorize2021::calculate_theta_R(const TVector3& ele_mom, co
     return std::acos(cos_theta) * 1000.0;
 }
 
+Track* PreselectAndCategorize2021::createInferredTrack(Vertex* vtx, Track* ele_track, Track* pos_track) {
+
+    Track* inferredTrack = new Track();
+
+    TVector3 ele_mom(ele_track->getMomentum()[0], ele_track->getMomentum()[1], ele_track->getMomentum()[2]);
+    TVector3 pos_mom(pos_track->getMomentum()[0], pos_track->getMomentum()[1], pos_track->getMomentum()[2]);
+
+    // Beam 4-momentum (assume m_e ~ 0 for the beam)
+    double theta_beam = thetaBeamMrad_ / 1000.0;  // convert to radians
+    double beam_px = beamE_ * std::sin(theta_beam);
+    double beam_py = 0.0;
+    double beam_pz = beamE_ * std::cos(theta_beam);
+
+    // Inferred recoil 3-momentum from momentum conservation
+    double recoil_px =  beam_px - ele_mom.X() - pos_mom.X();
+    double recoil_py = beam_py - ele_mom.Y() - pos_mom.Y();
+    double recoil_pz = beam_pz - ele_mom.Z() - pos_mom.Z();
+
+    float inferredCharge = -1; // Third track is an electron
+    float pT = std::sqrt(ele_mom.X()*ele_mom.X() + ele_mom.Z()*ele_mom.Z());
+    float cB = pT * fabs(ele_track->getOmega());
+
+
+
+    float target_pos = -1.1;
+    // Calculate track parameters
+    std::vector<float> params = TrackTools::calculateTrackParameters(
+        vtx->getX(), vtx->getY(), vtx->getZ(),
+        recoil_px, recoil_py, recoil_pz, inferredCharge, cB, target_pos);
+
+    inferredTrack->setTrackParameters(
+        params[0],  // d0
+        params[1],  // phi0
+        params[2],  // omega
+        params[4],  // tanLambda
+        params[3]   // z0
+    );
+
+    TMatrixD covVertex = TrackTools::getVertexCovariance(vtx);
+
+    TMatrixD eleCovMomentum = TrackTools::momentumCovarianceFromTrack(ele_track);
+    TMatrixD posCovMomentum = TrackTools::momentumCovarianceFromTrack(pos_track);
+
+    TMatrixD covMomentum = eleCovMomentum + posCovMomentum;
+
+    // Calculate track parameter covariance
+    TMatrixD covTrackParams = TrackTools::calculateTrackCovariance(
+        vtx->getX(), vtx->getY(), vtx->getZ(),
+        recoil_px, recoil_py, recoil_pz,
+        covVertex, covMomentum,
+        inferredCharge, cB, target_pos);
+
+
+    // Order: [d0, phi0, omega, z0, tanLambda]
+    std::vector<float> covArray;
+    covArray.reserve(15);
+    
+    for (int i = 0; i < 5; i++) {
+        for (int j = 0; j <= i; j++) {  
+            covArray.push_back(covTrackParams(j, i));
+        }
+    }
+    
+    inferredTrack->setCov(covArray);
+    
+    // Set momentum
+    inferredTrack->setMomentum(recoil_px, recoil_py, recoil_pz);
+
+    return inferredTrack;
+
+}
+
+
+bool PreselectAndCategorize2021::isQualityTrack(Track* trk, const Particle& pos) const {
+    // chi2/ndf <= 20
+    if (trk->getChi2Ndf() > 20.0) return false;
+    
+    // n_hits
+    int nhits = trk->getTrackerHitCount();
+    if (!trk->isKalmanTrack()) nhits *= 2;
+    if (nhits < minHits_) return false;
+    
+    // p >= 0.4
+    double p = trk->getP();
+    if (p < 0.4) return false;
+    
+    // for electrons (charge = -1), p <= 2.9
+    if (trk->getCharge() < 0 && p > 2.9) return false;
+    
+    // Timing cuts relative to preselection positron
+    double trk_time = trk->getTrackTime();
+    double pos_trk_time = pos.getTrack().getTrackTime();
+    double pos_clu_time = pos.getCluster().getTime();
+    
+    if (!disableTimingCuts_) {
+        if (trk->getCharge() < 0) {       
+            if (std::fabs(trk_time - pos_clu_time) > time_cuts_[0]) return false;
+            if (std::fabs(trk_time - pos_trk_time) > time_cuts_[2]) return false;  
+        } else if (trk->getCharge() > 0) {
+            if (std::fabs(trk_time - pos_clu_time) > time_cuts_[1]) return false;
+            if (std::fabs(trk_time - pos_trk_time) > time_cuts_[2]) return false;
+        }
+    }
+    
+    return true;
+}
+
+void PreselectAndCategorize2021::calculatePairwiseQuantities(
+    const std::vector<Track*>& all_tracks,
+    Particle& ele,
+    Particle& pos)
+{
+    // Select quality tracks with good timing relative to preselection positron
+    std::vector<Track> electrons, positrons;
+    std::vector<Track> all_good_tracks;
+    
+    // include the preselected electron and positron first
+    Track ele_trk = ele.getTrack();
+    Track pos_trk = pos.getTrack();
+    
+    if (ele_trk.getCharge() < 0) {
+        electrons.push_back(ele_trk);
+        if (saveAllTracks_) all_good_tracks.push_back(ele_trk);
+    }
+    
+    if (pos_trk.getCharge() > 0) {
+        positrons.push_back(pos_trk);
+        if (saveAllTracks_) all_good_tracks.push_back(pos_trk);
+    }
+    
+    // Track which tracks from the collection we've already included
+    std::set<int> included_track_ids;
+    if (ele_trk.getID() >= 0) included_track_ids.insert(ele_trk.getID());
+    if (pos_trk.getID() >= 0) included_track_ids.insert(pos_trk.getID());
+    
+    // Then check additional tracks from the collection
+    for (auto* trk : all_tracks) {
+        // Skip if this is the same track as preselected electron or positron
+        if (trk->getID() >= 0 && included_track_ids.count(trk->getID()) > 0) {
+            continue;
+        }
+        
+        if (!isQualityTrack(trk, pos)) continue;
+        
+        // Store a copy of the good track
+        if (saveAllTracks_) {
+            all_good_tracks.push_back(*trk);
+        }
+        
+        if (trk->getCharge() < 0) {
+            electrons.push_back(*trk);
+        } else if (trk->getCharge() > 0) {
+            positrons.push_back(*trk);
+        }
+    }
+    
+    // Save all good tracks if enabled
+    if (saveAllTracks_) {
+        bus_.set("all_preselected_tracks", all_good_tracks);
+    }
+    
+    // Initialize extrema values
+    double min_dTanLambda = 9999.0, max_dTanLambda = -9999.0;
+    double min_opening = 9999.0, max_opening = -9999.0;
+    double min_mass = 9999.0, max_mass = -9999.0;
+    double min_asym = 9999.0, max_asym = -9999.0;
+    double min_dPhi = 9999.0, max_dPhi = -9999.0;
+    
+    const double me = 0.000511; 
+    
+    // Loop over all e+/e- pairs
+    for (auto& ele_track : electrons) {
+        const std::vector<double>& ele_mom = ele_track.getMomentum();
+        TVector3 pe(ele_mom[0], ele_mom[1], ele_mom[2]);
+        double pe_mag = pe.Mag();
+        double ele_tanLambda = ele_track.getTanLambda();
+        double ele_phi0 = ele_track.getPhi();
+        
+        for (auto& pos_track : positrons) {
+            const std::vector<double>& pos_mom = pos_track.getMomentum();
+            TVector3 pp(pos_mom[0], pos_mom[1], pos_mom[2]);
+            double pp_mag = pp.Mag();
+            double pos_tanLambda = pos_track.getTanLambda();
+            double pos_phi0 = pos_track.getPhi();
+            
+            // TanLambda difference
+            double dTanLambda = std::fabs(ele_tanLambda - pos_tanLambda);
+            min_dTanLambda = std::min(min_dTanLambda, dTanLambda);
+            max_dTanLambda = std::max(max_dTanLambda, dTanLambda);
+            
+            // Phi difference
+            double dPhi = std::fabs(ele_phi0 - pos_phi0);
+            min_dPhi = std::min(min_dPhi, dPhi);
+            max_dPhi = std::max(max_dPhi, dPhi);
+            
+            // Opening angle
+            double cos_theta = pe.Dot(pp) / (pe_mag * pp_mag);
+            cos_theta = std::max(-1.0, std::min(1.0, cos_theta));
+            double opening_angle = std::acos(cos_theta);
+            min_opening = std::min(min_opening, opening_angle);
+            max_opening = std::max(max_opening, opening_angle);
+            
+            // Invariant mass
+            double Ee = std::sqrt(pe_mag * pe_mag + me * me);
+            double Ep = std::sqrt(pp_mag * pp_mag + me * me);
+            TVector3 p_tot = pe + pp;
+            double E_tot = Ee + Ep;
+            double m2 = E_tot * E_tot - p_tot.Mag2();
+            double mass = (m2 > 0) ? std::sqrt(m2) : 0.0;
+            min_mass = std::min(min_mass, mass);
+            max_mass = std::max(max_mass, mass);
+            
+            // Asymmetry
+            double asymmetry = std::fabs(pe_mag - pp_mag) / (pe_mag + pp_mag);
+            min_asym = std::min(min_asym, asymmetry);
+            max_asym = std::max(max_asym, asymmetry);
+        }
+    }
+    
+    // Store results (use -9999 if no pairs found)
+    bool has_pairs = (!electrons.empty() && !positrons.empty());
+    
+    bus_.set("min_dTanLambda", has_pairs ? min_dTanLambda : -9999.0);
+    bus_.set("max_dTanLambda", has_pairs ? max_dTanLambda : -9999.0);
+    bus_.set("min_opening", has_pairs ? min_opening : -9999.0);
+    bus_.set("max_opening", has_pairs ? max_opening : -9999.0);
+    bus_.set("min_mass", has_pairs ? min_mass : -9999.0);
+    bus_.set("max_mass", has_pairs ? max_mass : -9999.0);
+    bus_.set("min_asym", has_pairs ? min_asym : -9999.0);
+    bus_.set("max_asym", has_pairs ? max_asym : -9999.0);
+    bus_.set("min_dPhi", has_pairs ? min_dPhi : -9999.0);
+    bus_.set("max_dPhi", has_pairs ? max_dPhi : -9999.0);
+}
+
 void PreselectAndCategorize2021::initialize(TTree* tree) {
     _ah = std::make_shared<AnaHelpers>();
 
@@ -249,6 +489,7 @@ void PreselectAndCategorize2021::setFile(TFile* out_file) {
     bus_.board_output<Vertex>(output_tree_.get(), "vertex");
     bus_.board_output<Particle>(output_tree_.get(), "ele");
     bus_.board_output<Particle>(output_tree_.get(), "pos");
+    bus_.board_output<Track>(output_tree_.get(), "third_track");
     bus_.board_output<double>(output_tree_.get(), "psum");
     bus_.board_output<double>(output_tree_.get(), "psum_scalar");
     bus_.board_output<double>(output_tree_.get(), "epem_opening_angle");
@@ -315,6 +556,20 @@ void PreselectAndCategorize2021::setFile(TFile* out_file) {
     // vertical impact parameter
     for (const auto& name : {"min_y0", "max_y0err", "min_y0err", "ele_y0err", "pos_y0err", "min_y0_vtx", "min_y0_vtx_proj", "vtx_y_at_zero", "delta_y0_vtx_proj"}) {
         bus_.board_output<double>(output_tree_.get(), name);
+    }
+
+    if (calcMultiTrackVars_) {
+        for (const auto& extrema : {"min", "max"}) {
+            bus_.board_output<double>(output_tree_.get(), std::string(extrema) + "_dTanLambda");
+            bus_.board_output<double>(output_tree_.get(), std::string(extrema) + "_opening");
+            bus_.board_output<double>(output_tree_.get(), std::string(extrema) + "_mass");
+            bus_.board_output<double>(output_tree_.get(), std::string(extrema) + "_asym");
+            bus_.board_output<double>(output_tree_.get(), std::string(extrema) + "_dPhi");
+        }
+    }
+
+    if (saveAllTracks_) {
+        bus_.board_output<std::vector<Track>>(output_tree_.get(), "all_preselected_tracks");
     }
 
     if (bus_.has(mcColl_)) {
@@ -434,6 +689,7 @@ bool PreselectAndCategorize2021::process(IEvent*) {
         if (not v0proj_fits_.empty()) {
             int run = eh.getRunNumber();
             int closest_run;
+            closest_run = std::stoi((*v0proj_fits_.items().begin()).key());
             for (auto entry : v0proj_fits_.items()) {
                 int check_run = std::stoi(entry.key());
                 if (check_run > run)
@@ -809,6 +1065,8 @@ bool PreselectAndCategorize2021::process(IEvent*) {
     bus_.set("epem_opening_angle", ele_mom.Angle(pos_mom));
     bus_.set("recoil_theta", calculate_theta_R(ele_mom, pos_mom));
 
+    Track thirdTrack = *dynamic_cast<Track*>(createInferredTrack(&vtx, &ele_trk, &pos_trk));
+
     // calculate target projection and its significance
     if (not v0proj_fits_.empty()) {
         double vtx_proj_x{-1.0}, vtx_proj_y{-1.0};
@@ -899,6 +1157,26 @@ bool PreselectAndCategorize2021::process(IEvent*) {
     bus_.set("vertex", vtx);
     bus_.set("ele", ele);
     bus_.set("pos", pos);
+    bus_.set("third_track", thirdTrack);
+
+    //set multi-track quantities
+    if (calcMultiTrackVars_ && bus_.has(trkColl_)) {
+        const auto& all_tracks = bus_.get<std::vector<Track*>>(trkColl_);
+        calculatePairwiseQuantities(all_tracks, ele, pos);
+    } else if (saveAllTracks_ && bus_.has(trkColl_)) {
+        // if we only want to save tracks but not calculate pairwise quantities
+        const auto& all_tracks = bus_.get<std::vector<Track*>>(trkColl_);
+        std::vector<Track> all_good_tracks;
+        
+        for (auto* trk : all_tracks) {
+            if (isQualityTrack(trk, pos)) {
+                all_good_tracks.push_back(*trk);
+            }
+        }
+        
+        bus_.set("all_preselected_tracks", all_good_tracks);
+    }
+    
 
     /**
      * This is where the output TTree is filled,

--- a/processors/src/TrackTools.cxx
+++ b/processors/src/TrackTools.cxx
@@ -1,0 +1,465 @@
+#include "TrackTools.h"
+#include <iostream>
+#include <cmath>
+
+
+float TrackTools::normalizeAngle(float angle) {
+    const float PI = M_PI;
+    while (angle > PI) angle -= 2.0 * PI;
+    while (angle < -PI) angle += 2.0 * PI;
+    return angle;
+}
+
+
+TMatrixD TrackTools::getTrackCovariance(Track* track) {
+    TMatrixD cov(5, 5);
+    std::vector<float> covArray = track->getCov();
+    
+    if (covArray.size() < 15) {
+        std::cerr << "WARNING: Track covariance array size = " << covArray.size() 
+                  << ", expected 15" << std::endl;
+        return cov;
+    }
+    
+    int idx = 0;
+    for (int j = 0; j < 5; j++) {         
+        for (int i = 0; i <= j; i++) {   
+            cov(i, j) = covArray[idx];
+            cov(j, i) = covArray[idx];  
+            idx++;
+        }
+    }
+    return cov;
+}
+
+
+TMatrixD TrackTools::getVertexCovariance(Vertex* vtx) {
+    TMatrixD cov(3, 3);
+    
+    // Vertex covariance matrix
+    std::vector<float> covArray = vtx->getCovariance();
+    
+    if (covArray.size() < 6) {
+        std::cerr << "WARNING: Vertex covariance array size = " << covArray.size() 
+                  << ", expected 6" << std::endl;
+        return cov;
+    }
+    
+    cov(0, 0) = covArray[0]; // Var(x)
+    cov(0, 1) = covArray[1]; // Cov(x,y)
+    cov(1, 0) = covArray[1];
+    cov(1, 1) = covArray[2]; // Var(y)
+    cov(0, 2) = covArray[3]; // Cov(x,z)
+    cov(2, 0) = covArray[3];
+    cov(1, 2) = covArray[4]; // Cov(y,z)
+    cov(2, 1) = covArray[4];
+    cov(2, 2) = covArray[5]; // Var(z)
+    
+    return cov;
+}
+
+
+TMatrixD TrackTools::momentumCovarianceFromTrack(
+    double px, double py, double pz,
+    double phi0, double omega, double tanLambda,
+    const TMatrixD& covTrack) {
+    
+    // Calculate pT from momentum components
+    double pT = std::sqrt(px*px + pz*pz);
+    double pT2 = pT * pT;
+    double pT3 = pT * pT2;
+    
+    // We need to infer bfield*MOM_PARAM from the relationship:
+    // pt = |1/omega| * bfield * MOM_PARAM
+    double bfield_times_mom = pT * std::fabs(omega);
+    
+    double sign_omega = (omega > 0) ? 1.0 : -1.0;
+    
+    double sin_phi0 = std::sin(phi0);
+    double cos_phi0 = std::cos(phi0);
+    
+    // Derivatives
+    double dpt_domega = -sign_omega / (omega * omega) * bfield_times_mom;
+    
+    // Jacobian matrix: d[px, py, pz]/d[d0, phi0, omega, z0, tanLambda]
+    TMatrixD J(3, 5);
+    
+    // Row 0: px = pT * sin(phi0)
+    J(0, 0) = 0.0;                    // d(px)/d(d0)
+    J(0, 1) = pT * cos_phi0;          // d(px)/d(phi0)
+    J(0, 2) = dpt_domega * sin_phi0;  // d(px)/d(omega)
+    J(0, 3) = 0.0;                    // d(px)/d(z0)
+    J(0, 4) = 0.0;                    // d(px)/d(tanLambda)
+    
+    // Row 1: py = pT * tanLambda
+    J(1, 0) = 0.0;                      // d(py)/d(d0)
+    J(1, 1) = 0.0;                      // d(py)/d(phi0)
+    J(1, 2) = dpt_domega * tanLambda;   // d(py)/d(omega)
+    J(1, 3) = 0.0;                      // d(py)/d(z0)
+    J(1, 4) = pT;                       // d(py)/d(tanLambda)
+    
+    // Row 2: pz = pT * cos(phi0)
+    J(2, 0) = 0.0;                    // d(pz)/d(d0)
+    J(2, 1) = -pT * sin_phi0;         // d(pz)/d(phi0)
+    J(2, 2) = dpt_domega * cos_phi0;  // d(pz)/d(omega)
+    J(2, 3) = 0.0;                    // d(pz)/d(z0)
+    J(2, 4) = 0.0;                    // d(pz)/d(tanLambda)
+    
+    // Propagate covariance: Cov_p = J * Cov_track * J^T
+    TMatrixD J_T(TMatrixD::kTransposed, J);
+    TMatrixD temp = J * covTrack;
+    TMatrixD covMomentum = temp * J_T;
+    
+    return covMomentum;
+}
+
+TMatrixD TrackTools::momentumCovarianceFromTrack(Track* track) {
+    TMatrixD covTrack = getTrackCovariance(track);
+    
+    return momentumCovarianceFromTrack(
+        track->getMomentum()[0],
+        track->getMomentum()[1],
+        track->getMomentum()[2],
+        track->getPhi(),
+        track->getOmega(),
+        track->getTanLambda(),
+        covTrack);
+}
+
+
+std::vector<float> TrackTools::calculateTrackParameters(
+    float x_vtx, float y_vtx, float z_vtx,
+    float px, float py, float pz, float Q, float cB,
+    float targetPos) {
+    
+    // Transverse momentum
+    float pT = std::sqrt(px*px + pz*pz);
+    float omega = -Q * cB / pT;
+    
+    // Basic track parameters
+    float tan_lambda = py / pT;
+    float phi0 = std::atan2(px, pz);
+    
+    // Transform to helix convention
+    float tan_L_helix = -tan_lambda;
+    float phi0_helix = -phi0;
+    float alpha_over_kappa = -1.0 / omega;
+    
+    // Helix center in transverse (x-z) plane
+    float cos_phi0_h = std::cos(phi0_helix);
+    float sin_phi0_h = std::sin(phi0_helix);
+    
+    float x_center = x_vtx + alpha_over_kappa * cos_phi0_h;
+    float z_center = z_vtx + alpha_over_kappa * sin_phi0_h;
+    
+
+    // Angle to pivot point
+    float phi0_new_helix = std::atan2(targetPos - z_center, -x_center);
+    float cos_phi_new = std::cos(phi0_new_helix);
+    float sin_phi_new = std::sin(phi0_new_helix);
+    
+    // Impact parameter d0
+    float d0_helix = (x_center * cos_phi_new + 
+                       (z_center - targetPos) * sin_phi_new - 
+                       alpha_over_kappa);
+    
+    // z0 calculation
+    float phi_diff = phi0_new_helix - phi0_helix;
+    float dz_helix = -y_vtx - alpha_over_kappa * phi_diff * tan_L_helix;
+    
+    // Transform back 
+    std::vector<float> params;
+    params.push_back(d0_helix);           // d0
+    params.push_back(-phi0_new_helix);    // phi0
+    params.push_back(omega);              // omega
+    params.push_back(-dz_helix);          // z0
+    params.push_back(tan_lambda);         // tan_lambda
+    
+    // Normalize phi0
+    params[1] = normalizeAngle(params[1]);
+    
+    return params;
+}
+
+
+TMatrixD TrackTools::trackParametersJacobian(
+    float x_vtx, float y_vtx, float z_vtx,
+    float px, float py, float pz,
+    float Q, float cB,
+    float targetPos) {
+    
+    // ---- Intermediate quantities ----
+    float pT2 = px*px + pz*pz;
+    float pT = std::sqrt(pT2);
+    float pT3 = pT * pT2;
+
+    float omega = -Q * cB / pT;
+    
+    float tan_lambda = py / pT;
+    float phi0 = std::atan2(px, pz);
+    
+    // Helix frame
+    float tan_L_helix = -tan_lambda;
+    float phi0_helix = -phi0;
+    float alpha_over_kappa = -1.0 / omega;
+    
+    float cos_phi0_h = std::cos(phi0_helix);
+    float sin_phi0_h = std::sin(phi0_helix);
+    
+    // Center position
+    float x_center = x_vtx + alpha_over_kappa * cos_phi0_h;
+    float z_center = z_vtx + alpha_over_kappa * sin_phi0_h;
+    
+    // To pivot
+    double dx_c = -x_center;
+    double dz_c = targetPos - z_center;
+    float r_c2 = dx_c*dx_c + dz_c*dz_c;
+
+    float phi0_new_helix = std::atan2(dz_c, dx_c);
+    float cos_phi_new = std::cos(phi0_new_helix);
+    float sin_phi_new = std::sin(phi0_new_helix);
+    
+    float phi_diff = phi0_new_helix - phi0_helix;
+    
+    // ---- Derivatives of basic quantities ----
+    
+    // d(pT)/d(px), d(pT)/d(pz)
+    float dpT_dpx = px / pT;
+    float dpT_dpz = pz / pT;
+    
+    // d(phi0)/d(px), d(phi0)/d(pz)
+    // phi0 = atan2(px, pz)
+    float dphi0_dpx = pz / pT2;
+    float dphi0_dpz = -px / pT2;
+    
+    // d(phi0_helix)/d(px), d(phi0_helix)/d(pz)
+    float dphi0h_dpx = -dphi0_dpx;
+    float dphi0h_dpz = -dphi0_dpz;
+    
+    // d(tan_lambda)/d(px), d(tan_lambda)/d(py), d(tan_lambda)/d(pz)
+    float dtanL_dpx = -py * px / pT3;
+    float dtanL_dpy = 1.0 / pT;
+    float dtanL_dpz = -py * pz / pT3;
+    
+    //d(omega)/d(pT)
+    float domega_dpT = Q * cB / pT2;
+
+    //d(alpha_over_kappa)/d(px)
+    float dalpha_over_kappa_dpx = (1 / (omega*omega)) * domega_dpT * dpT_dpx;
+    float dalpha_over_kappa_dpy = 0;
+    float dalpha_over_kappa_dpz = (1 / (omega*omega)) * domega_dpT * dpT_dpz;
+
+
+    
+    // d(x_center)/d(x), d(x_center)/d(px), etc.
+    float dxc_dx = 1.0;
+    float dxc_dpx = -alpha_over_kappa * sin_phi0_h * dphi0h_dpx + cos_phi0_h * dalpha_over_kappa_dpx;
+    float dxc_dpz = -alpha_over_kappa * sin_phi0_h * dphi0h_dpz + cos_phi0_h * dalpha_over_kappa_dpz;
+    
+    // d(z_center)/d(z), d(z_center)/d(px), etc.
+    float dzc_dz = 1.0;
+    float dzc_dpx = alpha_over_kappa * cos_phi0_h * dphi0h_dpx + sin_phi0_h * dalpha_over_kappa_dpx;
+    float dzc_dpz = alpha_over_kappa * cos_phi0_h * dphi0h_dpz + sin_phi0_h * dalpha_over_kappa_dpz;
+    
+    // d(phi0_new_helix)/d(x_center), d(phi0_new_helix)/d(z_center)
+    float dphi0new_dxc = dz_c / r_c2;
+    float dphi0new_dzc = -dx_c / r_c2;
+    
+    // d(phi0_new_helix)/d(x), d(phi0_new_helix)/d(z), etc.
+    float dphi0new_dx = dphi0new_dxc * (dxc_dx);
+    float dphi0new_dz = dphi0new_dzc * (dzc_dz);
+    float dphi0new_dpx = dphi0new_dxc * (dxc_dpx) + dphi0new_dzc * (dzc_dpx);
+    float dphi0new_dpz = dphi0new_dxc * (dxc_dpz) + dphi0new_dzc * (dzc_dpz);
+    
+    // ---- Build Jacobian ----
+    TMatrixD J(5, 6);
+    
+    // ========================================
+    // Row 0: d0
+    // ========================================
+    // d0 = x_center * cos(phi0_new) + (z_center - target) * sin(phi0_new) - alpha_over_kappa
+    
+
+    double phi_term = -(x_center * sin_phi_new) + (z_center - targetPos) * cos_phi_new;
+
+    double dd0_dxc = cos_phi_new + phi_term * dphi0new_dxc;
+    double dd0_dzc = sin_phi_new + phi_term * dphi0new_dzc;
+    
+    J(0, 0) = dd0_dxc * dxc_dx;  // d(d0)/d(x)
+    J(0, 1) = 0.0;                // d(d0)/d(y)
+    J(0, 2) = dd0_dzc * dzc_dz;  // d(d0)/d(z)
+    J(0, 3) = dd0_dxc * dxc_dpx + dd0_dzc * dzc_dpx - dalpha_over_kappa_dpx;  // d(d0)/d(px)
+    J(0, 4) = 0.0;                // d(d0)/d(py)
+    J(0, 5) = dd0_dxc * dxc_dpz + dd0_dzc * dzc_dpz - dalpha_over_kappa_dpz;  // d(d0)/d(pz)
+    
+    // ========================================
+    // Row 1: phi0_new = -phi0_new_helix
+    // ========================================
+    
+    J(1, 0) = -dphi0new_dx;   // d(phi0)/d(x)
+    J(1, 1) = 0.0;            // d(phi0)/d(y)
+    J(1, 2) = -dphi0new_dz;   // d(phi0)/d(z)
+    J(1, 3) = -dphi0new_dpx;  // d(phi0)/d(px)
+    J(1, 4) = 0.0;            // d(phi0)/d(py)
+    J(1, 5) = -dphi0new_dpz;  // d(phi0)/d(pz)
+    
+    // ========================================
+    // Row 2: omega (constant - given from original track)
+    // ========================================
+    
+    J(2, 0) = 0.0;  // d(omega)/d(x)
+    J(2, 1) = 0.0;  // d(omega)/d(y)
+    J(2, 2) = 0.0;  // d(omega)/d(z)
+    J(2, 3) = domega_dpT * dpT_dpx;  // d(omega)/d(px)
+    J(2, 4) = 0.0;  // d(omega)/d(py)
+    J(2, 5) = domega_dpT * dpT_dpz;  // d(omega)/d(pz)
+    
+    // ========================================
+    // Row 3: z0 = -dz_helix = y + alpha * phi_diff * tan_lambda
+    // ========================================
+    
+    // d(phi_diff)/d(phi0_new_helix) = 1
+    // d(phi_diff)/d(phi0_helix) = -1
+    
+    J(3, 0) = alpha_over_kappa * tan_L_helix * dphi0new_dx;  // d(z0)/d(x)
+    J(3, 1) = 1.0;                                            // d(z0)/d(y)
+    J(3, 2) = alpha_over_kappa * tan_L_helix * dphi0new_dz;  // d(z0)/d(z)
+    
+    // d(z0)/d(px) = d(y + alpha*phi_diff*tan_L)/d(px)
+    //             = alpha * (dphi_diff/dpx) * tan_L + alpha * phi_diff * (dtan_L/dpx) +
+    //               phi_diff*tan_L*(dalpha_dpx)
+    // where dphi_diff/dpx = dphi0new/dpx - dphi0h/dpx
+    double dphidiff_dpx = dphi0new_dpx - dphi0h_dpx;
+    double dphidiff_dpz = dphi0new_dpz - dphi0h_dpz;
+    
+    J(3, 3) = alpha_over_kappa * (dphidiff_dpx * tan_L_helix - phi_diff * dtanL_dpx) + phi_diff * tan_L_helix * dalpha_over_kappa_dpx;
+    J(3, 4) = -alpha_over_kappa * phi_diff * dtanL_dpy;
+    J(3, 5) = alpha_over_kappa * (dphidiff_dpz * tan_L_helix - phi_diff * dtanL_dpz) + phi_diff * tan_L_helix * dalpha_over_kappa_dpz;
+    
+    // ========================================
+    // Row 4: tan_lambda (depends only on momentum)
+    // ========================================
+    
+    J(4, 0) = 0.0;         // d(tanL)/d(x)
+    J(4, 1) = 0.0;         // d(tanL)/d(y)
+    J(4, 2) = 0.0;         // d(tanL)/d(z)
+    J(4, 3) = dtanL_dpx;   // d(tanL)/d(px)
+    J(4, 4) = dtanL_dpy;   // d(tanL)/d(py)
+    J(4, 5) = dtanL_dpz;   // d(tanL)/d(pz)
+    
+    return J;
+}
+
+
+
+TMatrixD TrackTools::buildCombinedCovariance(
+    const TMatrixD& covVertex,
+    const TMatrixD& covMomentum,
+    const TMatrixD* covCross) {
+    
+    TMatrixD cov(6, 6);
+    
+    // Upper-left 3x3: position covariance
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            cov(i, j) = covVertex(i, j);
+        }
+    }
+    
+    // Lower-right 3x3: momentum covariance
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            cov(i+3, j+3) = covMomentum(i, j);
+        }
+    }
+    
+    // Off-diagonal blocks: position-momentum correlation
+    if (covCross != nullptr) {
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                cov(i, j+3) = (*covCross)(i, j);
+                cov(j+3, i) = (*covCross)(i, j); 
+            }
+        }
+    } else {
+        // No correlation between position and momentum
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                cov(i, j+3) = 0.0;
+                cov(j+3, i) = 0.0;
+            }
+        }
+    }
+    
+    return cov;
+}
+
+
+TMatrixD TrackTools::calculateTrackCovariance(
+    float x_vtx, float y_vtx, float z_vtx,
+    float px, float py, float pz,
+    const TMatrixD& covVertex,
+    const TMatrixD& covMomentum,
+    float Q, float cB, float targetPos) {
+    
+    // Get Jacobian: d[track params]/d[x,y,z,px,py,pz]
+    TMatrixD J = trackParametersJacobian(
+        x_vtx, y_vtx, z_vtx,
+        px, py, pz, Q, cB, targetPos);
+    
+    // Build 6x6 combined covariance matrix
+    TMatrixD cov6x6 = buildCombinedCovariance(covVertex, covMomentum);
+    
+    // Propagate covariance: Cov_track = J * Cov_6x6 * J^T
+    TMatrixD J_T(TMatrixD::kTransposed, J);
+    TMatrixD temp = J * cov6x6;
+    TMatrixD covTrack = temp * J_T;
+    
+    return covTrack;
+}
+
+
+TMatrixD TrackTools::numericalJacobian(
+    float x_vtx, float y_vtx, float z_vtx,
+    float px, float py, float pz,
+    float Q, float cB, float targetPos) {
+    
+    const double epsilon = 1e-4;
+    TMatrixD J_num(5, 6);
+    
+    // Get nominal track parameters
+    std::vector<float> params_nominal = TrackTools::calculateTrackParameters(
+        x_vtx, y_vtx, z_vtx, px, py, pz, Q, cB, targetPos);
+    
+    // Vary each input parameter
+    std::vector<double> inputs = {x_vtx, y_vtx, z_vtx, px, py, pz};
+    
+    for (int j = 0; j < 6; j++) {
+        std::vector<double> inputs_plus = inputs;
+        inputs_plus[j] += epsilon;
+        
+        std::vector<float> params_plus = TrackTools::calculateTrackParameters(
+            inputs_plus[0], inputs_plus[1], inputs_plus[2],
+            inputs_plus[3], inputs_plus[4], inputs_plus[5],
+            Q, cB, targetPos);
+        
+        // Compute derivatives
+        for (int i = 0; i < 5; i++) {
+            J_num(i, j) = (params_plus[i] - params_nominal[i]) / epsilon;
+            
+            // Handle angle wrapping for phi0
+            if (i == 1) {
+                double diff = params_plus[i] - params_nominal[i];
+                if (diff > M_PI) diff -= 2*M_PI;
+                if (diff < -M_PI) diff += 2*M_PI;
+                J_num(i, j) = diff / epsilon;
+            }
+        }
+    }
+    
+    return J_num;
+}
+
+
+
+

--- a/processors/src/utilities.cxx
+++ b/processors/src/utilities.cxx
@@ -850,6 +850,7 @@ double utils::v0_projection_to_target_significance(json v0proj_fits, int run, do
 
     // Read v0 projection fits from json file
     int closest_run;
+    closest_run = std::stoi((*v0proj_fits.items().begin()).key());
     for (auto entry : v0proj_fits.items()) {
         int check_run = std::stoi(entry.key());
         if (check_run > run)
@@ -934,6 +935,7 @@ double utils::v0_projection_to_target_significance(json v0proj_fits, int run, do
                                                    bool debug) {
     // Read v0 projection fits from json file
     int closest_run;
+    closest_run = std::stoi((*v0proj_fits.items().begin()).key());
     for (auto entry : v0proj_fits.items()) {
         int check_run = std::stoi(entry.key());
         if (check_run > run)


### PR DESCRIPTION
A few additions to the 2021 preselection code.

Includes flags for saving all tracks in the event, and calculating variables from all tracks in the event (min/max tanLambda, mass, asymmetry, etc. from all electron/positron pairs).

Also includes a calculation of an expected "third track" from the preselected vertex, including all five track parameters and covariance matrix. I validated this in MC among events where the third track was reconstructed. Pulls are a bit too wide, especially for phi0 and tanLambda (~2, closer to 1.2 for other variables), but overall reasonable. 